### PR TITLE
#12 Download folder with release_id

### DIFF
--- a/src/core/redux/actions/actions.js
+++ b/src/core/redux/actions/actions.js
@@ -2109,6 +2109,10 @@ export const addToCart = (type, item) => {
                 from: 0,
                 size: 0,
                 aggs: { count: { sum: { field: 'archive.size' } } },
+                sort: [{ ['release_id']: 'desc' }],
+                collapse: {
+                    field: 'uri',
+                },
                 track_total_hits: true,
             }
 

--- a/src/pages/Cart/Content/CartView/CartView.js
+++ b/src/pages/Cart/Content/CartView/CartView.js
@@ -221,8 +221,6 @@ const CartView = (props) => {
         return state.get('cart').toJS() || []
     })
 
-    console.log(cart)
-
     const gridContainerRef = useRef(null)
     const { width, height, ref } = useResizeDetector()
     const { widthR, heightR } = useSize(gridContainerRef)


### PR DESCRIPTION
Unfortunately we cannot collapse on scroll. We can collapse with search_after on the latest ES but not on the 7.10 version we're on. OpenSearch does not support collapsing on search_after yet either. https://github.com/opensearch-project/OpenSearch/issues/3725

Workaround:
- All documents are scrolled through for the folder (across all releases)
- Scroll sorts by uri and release id.
- Only the first instance of a uri is downloaded (the ones after are skipped).

Due to current venue setups, fully testing bulk downloads is difficult locally. Will merge but close issue afterwards.  