### PR TITLE
#14 Use float field for release_id

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "atlas4",
+  "name": "atlas",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "atlas4",
+      "name": "atlas",
       "version": "0.1.0",
       "dependencies": {
         "@babel/core": "7.8.4",

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -57,6 +57,7 @@ export const ES_PATHS = {
         bundle_id: ['archive', 'bundle_id'],
         volume_id: ['archive', 'volume_id'],
         pds_standard: ['archive', 'pds_standard'],
+        release_id: ['archive', 'release_id_num'],
     },
     pds4_label: {
         lidvid: ['pds4_label', 'lidvid'],

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -26,7 +26,7 @@ export const localStorageCart = 'ATLAS_CART'
 
 export const ES_PATHS = {
     source: ['uri'],
-    release_id: ['release_id'],
+    release_id: ['release_id_num'],
     related: ['gather', 'pds_archive', 'related'],
     ml: ['gather', 'machine_learning'],
     ml_classification_related: ['gather', 'machine_learning', 'classification', 'related'],

--- a/src/core/downloaders/ZipStream.js
+++ b/src/core/downloaders/ZipStream.js
@@ -294,7 +294,7 @@ const getQuery = (item, previousResult, productKeys) => {
         let dsl = {
             query: item.query,
             size: querySize,
-            sort: [{ ['uri']: 'desc', ['release_id']: 'desc' }],
+            sort: [{ ['uri']: 'desc', [ES_PATHS.release_id.join('.')]: 'desc' }],
             _source: ['uri', ES_PATHS.release_id.join('.'), ES_PATHS.related.join('.')],
         }
 

--- a/src/core/redux/actions/actions.js
+++ b/src/core/redux/actions/actions.js
@@ -678,13 +678,18 @@ export const search = (page, filtersNeedUpdate, pageNeedsUpdate, url, forceActiv
             query,
             from,
             size: resultsPerPage,
-            sort: [{ [resultSorting.field]: resultSorting.direction, ['release_id']: 'desc' }],
+            sort: [
+                {
+                    [resultSorting.field]: resultSorting.direction,
+                    [ES_PATHS.release_id.join('.')]: 'desc',
+                },
+            ],
             aggs,
             collapse: {
                 field: 'uri',
             },
             track_total_hits: true,
-            _source: ['uri', 'gather', 'release_id'],
+            _source: ['uri', 'gather', ES_PATHS.release_id.join('.')],
         }
 
         lastDSL = dsl
@@ -929,7 +934,7 @@ export const searchRecordByURI = (uri) => {
 
         const dsl = {
             query,
-            sort: [{ ['release_id']: 'desc' }],
+            sort: [{ [ES_PATHS.release_id.join('.')]: 'desc' }],
             collapse: {
                 field: 'uri',
             },
@@ -1709,7 +1714,12 @@ export const queryFilexColumn = (columnId, isLast, cb) => {
             query,
             from: from,
             size: column.type === 'directory' ? pageSize : 1,
-            sort: [{ [ES_PATHS.archive.name.join('.')]: 'asc', ['release_id']: 'desc' }],
+            sort: [
+                {
+                    [ES_PATHS.archive.name.join('.')]: 'asc',
+                    [ES_PATHS.release_id.join('.')]: 'desc',
+                },
+            ],
             collapse: {
                 field: 'uri',
             },
@@ -2109,7 +2119,7 @@ export const addToCart = (type, item) => {
                 from: 0,
                 size: 0,
                 aggs: { count: { sum: { field: 'archive.size' } } },
-                sort: [{ ['release_id']: 'desc' }],
+                sort: [{ [ES_PATHS.release_id.join('.')]: 'desc' }],
                 collapse: {
                     field: 'uri',
                 },

--- a/src/pages/Cart/Content/CartView/CartView.js
+++ b/src/pages/Cart/Content/CartView/CartView.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import PropTypes from 'prop-types'
 import { useLocation, useHistory } from 'react-router-dom'
-import { HASH_PATHS, AVAILABLE_URI_SIZES } from '../../../../core/constants'
+import { HASH_PATHS, AVAILABLE_URI_SIZES, ES_PATHS } from '../../../../core/constants'
 
 import clsx from 'clsx'
 
@@ -313,6 +313,8 @@ const GridCard = ({ index, data, width }) => {
         title = JSON.stringify(data.item.query, null, 1)
     else title = data.item.uri
 
+    const release_id = getIn(data, 'item.release_id', null)
+
     return (
         <div
             cart-index={index}
@@ -341,7 +343,7 @@ const GridCard = ({ index, data, width }) => {
             ) : null}
             {images &&
                 images.map((image, idx) => {
-                    const imgURL = getPDSUrl(image, null, AVAILABLE_URI_SIZES.sm)
+                    const imgURL = getPDSUrl(image, release_id, AVAILABLE_URI_SIZES.sm)
                     return (
                         <LazyLoad offset={600} key={idx} once>
                             <Image

--- a/src/pages/FileExplorer/Columns/Columns.js
+++ b/src/pages/FileExplorer/Columns/Columns.js
@@ -1075,7 +1075,9 @@ const Column = (props) => {
                                                                                   s.uri,
                                                                                   getIn(
                                                                                       s,
-                                                                                      ES_PATHS.release_id
+                                                                                      ES_PATHS
+                                                                                          .archive
+                                                                                          .release_id
                                                                                   )
                                                                               ),
                                                                               getFilename(s.uri)
@@ -1115,7 +1117,8 @@ const Column = (props) => {
                                                                               ),
                                                                               release_id: getIn(
                                                                                   s,
-                                                                                  ES_PATHS.release_id
+                                                                                  ES_PATHS.archive
+                                                                                      .release_id
                                                                               ),
                                                                               size: getIn(
                                                                                   s,

--- a/src/pages/FileExplorer/Columns/Columns.js
+++ b/src/pages/FileExplorer/Columns/Columns.js
@@ -429,7 +429,6 @@ const useStyles = makeStyles((theme) => ({
     },
     listItemButtons: {
         lineHeight: '25px',
-        position: 'absolute',
         right: '0px',
         background: theme.palette.swatches.grey.grey150,
         transition: 'opacity 0.2s ease-out',

--- a/src/pages/FileExplorer/Columns/Columns.js
+++ b/src/pages/FileExplorer/Columns/Columns.js
@@ -1074,7 +1074,10 @@ const Column = (props) => {
                                                                           streamDownloadFile(
                                                                               getPDSUrl(
                                                                                   s.uri,
-                                                                                  s.release_id
+                                                                                  getIn(
+                                                                                      s,
+                                                                                      ES_PATHS.release_id
+                                                                                  )
                                                                               ),
                                                                               getFilename(s.uri)
                                                                           )

--- a/src/pages/FileExplorer/Modals/RegexModal/RegexModal.js
+++ b/src/pages/FileExplorer/Modals/RegexModal/RegexModal.js
@@ -793,7 +793,10 @@ const RegexModal = (props) => {
                                                                     streamDownloadFile(
                                                                         getPDSUrl(
                                                                             s.uri,
-                                                                            s.release_id
+                                                                            getIn(
+                                                                                s,
+                                                                                ES_PATHS.release_id
+                                                                            )
                                                                         ),
                                                                         getFilename(s.uri)
                                                                     )

--- a/src/pages/FileExplorer/Preview/Preview.js
+++ b/src/pages/FileExplorer/Preview/Preview.js
@@ -360,7 +360,10 @@ const ButtonBar = (props) => {
                         disabled={preview.fs_type !== 'file'}
                         onClick={() => {
                             if (preview.uri)
-                                window.open(getPDSUrl(preview.uri, preview.release_id), '_blank')
+                                window.open(
+                                    getPDSUrl(preview.uri, getIn(preview, ES_PATHS.release_id)),
+                                    '_blank'
+                                )
                         }}
                     >
                         <LaunchIcon className={c.buttonIcon} fontSize={iconSize} />
@@ -376,7 +379,7 @@ const ButtonBar = (props) => {
                         onClick={() => {
                             if (preview.uri != null) {
                                 streamDownloadFile(
-                                    getPDSUrl(preview.uri, preview.release_id),
+                                    getPDSUrl(preview.uri, getIn(preview, ES_PATHS.release_id)),
                                     getFilename(preview.uri)
                                 )
                             }
@@ -400,7 +403,7 @@ const ButtonBar = (props) => {
                                     uri: preview.uri,
                                     related: related,
                                     size: preview.size,
-                                    release_id: preview.release_id,
+                                    release_id: getIn(preview, ES_PATHS.release_id),
                                 })
                             )
                             dispatch(setSnackBarText('Added to Cart!', 'success'))
@@ -450,7 +453,7 @@ const Preview = (props) => {
                     },
                 },
                 size: 1,
-                _source: ['uri', 'gather.pds_archive.related', 'release_id'],
+                _source: ['uri', 'gather.pds_archive.related', ES_PATHS.release_id.join('.')],
             }
 
             axios
@@ -488,7 +491,11 @@ const Preview = (props) => {
                         ],
                     },
                 },
-                _source: ['uri', ES_PATHS.pds4_label.lidvid.join('.'), 'release_id'],
+                _source: [
+                    'uri',
+                    ES_PATHS.pds4_label.lidvid.join('.'),
+                    ES_PATHS.release_id.join('.'),
+                ],
             }
 
             axios


### PR DESCRIPTION
## 🗒️ Summary
Use `release_id_num` instead of `release_id` when collapsing on release to avoid string order (i.e "11" coming before "2") and to support fractional release numbers.

Also makes the release_id path in constants.js the source-of-truth for the value.

## ♻️ Related Issues
Closes #14
This ticket also fixes the issue of using the wrong release_id path to quick-download items in the archive-explorer (and instead falling back to the cumulative entry)


