### PR TITLE
#23 Atlas - WGET download and scroll API not working

### DIFF
--- a/src/core/downloaders/CSV.js
+++ b/src/core/downloaders/CSV.js
@@ -11,13 +11,14 @@ const CSV_FILE_MAX_ROWS = 500000
 
 let CSVRows = []
 
-export const CSVCart = (productKeys, datestamp) => {
+export const CSVCart = (statusCallback, finishCallback, setOnStop, productKeys, datestamp) => {
     return (dispatch, getState) => {
         if (productKeys == null || productKeys.length === 0) productKeys = ['src']
 
         const state = getState()
         const cart = state.get('cart').toJS()
         const checkedCart = cart.filter((v) => v.checked === true)
+        const startTime = Date.now()
 
         const tasks = []
 
@@ -26,8 +27,17 @@ export const CSVCart = (productKeys, datestamp) => {
         checkedCart.forEach((d) => {
             tasks.push(async () => {
                 d.type === 'query' || d.type === 'directory' || d.type === 'regex'
-                    ? await CSVQuery(d.item, productKeys, d.type === 'directory', datestamp)
-                    : CSVImage(d.item, productKeys, datestamp)
+                    ? await CSVQuery(
+                          d.item,
+                          productKeys,
+                          d.type === 'directory',
+                          datestamp,
+                          statusCallback,
+                          finishCallback,
+                          setOnStop,
+                          startTime
+                      )
+                    : CSVImage(d.item, productKeys, datestamp, statusCallback)
             })
         })
 
@@ -35,21 +45,53 @@ export const CSVCart = (productKeys, datestamp) => {
             for (const task of tasks) {
                 await task()
             }
-            createCSVFile(datestamp)
+            createCSVFile(datestamp, finishCallback)
         }
 
         callTasks()
     }
 }
 
-const CSVQuery = (item, productKeys, keepFolderStructure, datestamp) => {
+const CSVQuery = (
+    item,
+    productKeys,
+    keepFolderStructure,
+    datestamp,
+    statusCallback,
+    finishCallback,
+    setOnStop,
+    startTime
+) => {
     return new Promise((resolve, reject) => {
         let totalReceived = 0
         let dsl = {
             query: item.query,
-            size: 10000,
-            _source: ['uri', ES_PATHS.related.join('.')],
+            size: 5000,
+            _source: ['uri', ES_PATHS.related.join('.'), ES_PATHS.archive.fs_type.join('.')],
         }
+        let stopped = false
+
+        setOnStop(() => () => {
+            stopped = true
+        })
+
+        sendStatus(
+            statusCallback,
+            null,
+            null,
+            null,
+            null,
+            (totalReceived / item.total) * 100,
+            totalReceived,
+            item.total,
+            item.total,
+            0,
+            Date.now() - startTime,
+            ((Date.now() - startTime) * item.total) / totalReceived - (Date.now() - startTime),
+            0
+        )
+
+        if (keepFolderStructure === true) productKeys = ['src']
 
         const filter_path = 'filter_path=hits.hits._source,hits.total,_scroll_id'
 
@@ -65,12 +107,30 @@ const CSVQuery = (item, productKeys, keepFolderStructure, datestamp) => {
             })
 
         const scroll = (res) => {
-            if (!res?.data?.hits) {
+            if (stopped === true || !res?.data?.hits) {
+                if (typeof finishCallback === 'function') {
+                    finishCallback(false)
+                }
                 reject()
                 return
             }
 
             totalReceived += res.data.hits.hits.length
+            sendStatus(
+                statusCallback,
+                null,
+                null,
+                null,
+                null,
+                (totalReceived / item.total) * 100,
+                totalReceived,
+                item.total,
+                item.total,
+                0,
+                Date.now() - startTime,
+                ((Date.now() - startTime) * item.total) / totalReceived - (Date.now() - startTime),
+                0
+            )
             res.data.hits.hits.forEach((r) => {
                 productKeys.forEach((key) => {
                     let path
@@ -78,6 +138,14 @@ const CSVQuery = (item, productKeys, keepFolderStructure, datestamp) => {
                     else path = getIn(r._source, ES_PATHS.related.concat([key, 'uri']))
                     const size = getIn(r._source, ES_PATHS.related.concat([key, 'size']), null)
                     if (path) {
+                        // Do no try downloading dirs
+                        // Make sure a . exists in the final part
+                        const fs_type = getIn(r._source, ES_PATHS.archive.fs_type)
+                        if (fs_type == null) {
+                            const pathSplit = path.split('/')
+                            if (pathSplit[pathSplit.length - 1].indexOf('.') == null) return
+                        } else if (fs_type === 'directory') return
+
                         const release_id = getIn(r._source, ES_PATHS.release_id)
                         let filename = getFilename(path)
 
@@ -95,7 +163,7 @@ const CSVQuery = (item, productKeys, keepFolderStructure, datestamp) => {
                     }
                 })
             })
-            if (CSVRows.length > CSV_FILE_MAX_ROWS) createCSVFile(datestamp)
+            if (CSVRows.length >= CSV_FILE_MAX_ROWS) createCSVFile(datestamp)
 
             if (totalReceived < item.total) {
                 return axios
@@ -118,22 +186,35 @@ const CSVQuery = (item, productKeys, keepFolderStructure, datestamp) => {
         }
     })
 }
-const CSVImage = (item, productKeys, datestamp) => {
-    productKeys.forEach((key) => {
+const CSVImage = (item, productKeys, datestamp, statusCallback) => {
+    productKeys.forEach((key, idx) => {
         let path
         if (key === 'src') path = item.uri
         else path = getIn(item.related, [key, 'uri'])
         const size = getIn(item.related, [key, 'size'], null)
+
         if (path) {
             const filename = getFilename(path)
             const pdsUri = getPDSUrl(path, item.release_id)
             if (filename && pdsUri) CSVRows.push(`${filename},${size},${path},${pdsUri}\n`)
         }
+
+        sendStatus(
+            statusCallback,
+            idx,
+            (idx / productKeys.length) * 100,
+            idx,
+            productKeys.length,
+            (idx / productKeys.length) * 100,
+            idx,
+            productKeys.length,
+            productKeys.length
+        )
     })
     return
 }
 
-const createCSVFile = (datestamp) => {
+const createCSVFile = (datestamp, finishCallback) => {
     if (CSVRows.length == 0) {
         alert('Nothing to download.')
         return
@@ -147,4 +228,33 @@ const createCSVFile = (datestamp) => {
 
     const blob = new Blob([CSVStr], { type: 'text/plain;charset=utf-8' })
     fileSaver.saveAs(blob, `pdsimg-atlas_${datestamp}.csv`, true)
+
+    if (typeof finishCallback === 'function') {
+        finishCallback(false)
+    }
+}
+
+const sendStatus = (cb, ccii, cp, cc, ct, op, oc, ot, otp, ob, oet, oetr, of1) => {
+    // Status
+    const status = {
+        current: {
+            currentItemIdx: ccii != null ? ccii : 0,
+            percent: cp != null ? cp : 100,
+            current: cc != null ? cc : 0,
+            total: ct != null ? ct : 1,
+        },
+        overall: {
+            percent: op != null ? op : 100,
+            current: oc != null ? oc : 0,
+            total: ot != null ? ot : 1,
+            totalProducts: otp != null ? otp : 1,
+            buffer: ob != null ? ob : 0,
+            elapsedTime: oet != null ? oet : 0,
+            estimatedTimeRemaining: oetr != null ? oetr : 0,
+            failures: of1 != null ? of1 : 0,
+        },
+    }
+    if (typeof cb === 'function') {
+        cb(status)
+    }
 }

--- a/src/core/downloaders/TXT.js
+++ b/src/core/downloaders/TXT.js
@@ -6,12 +6,12 @@ import { getHeader, getPDSUrl, getFilename, getIn } from '../utils'
 
 import fileSaver from 'file-saver'
 
-// ======================= CURL =======================
-const CURL_FILE_MAX_ROWS = 500000
+// ======================= TXT =======================
+const TXT_FILE_MAX_ROWS = 500000
 
-let CURLRows = []
+let TXTRows = []
 
-export const CURLCart = (productKeys, datestamp) => {
+export const TXTCart = (productKeys, datestamp) => {
     return (dispatch, getState) => {
         if (productKeys == null || productKeys.length === 0) productKeys = ['src']
 
@@ -21,13 +21,13 @@ export const CURLCart = (productKeys, datestamp) => {
 
         const tasks = []
 
-        CURLRows = []
+        TXTRows = []
 
         checkedCart.forEach((d) => {
             tasks.push(async () => {
                 d.type === 'query' || d.type === 'directory' || d.type === 'regex'
-                    ? await CURLQuery(d.item, productKeys, d.type === 'directory', datestamp)
-                    : CURLImage(d.item, productKeys, datestamp)
+                    ? await TXTQuery(d.item, productKeys, d.type === 'directory', datestamp)
+                    : TXTImage(d.item, productKeys, datestamp)
             })
         })
 
@@ -35,14 +35,14 @@ export const CURLCart = (productKeys, datestamp) => {
             for (const task of tasks) {
                 await task()
             }
-            createCURLFile(datestamp)
+            createTXTFile(datestamp)
         }
 
         callTasks()
     }
 }
 
-const CURLQuery = (item, productKeys, keepFolderStructure, datestamp) => {
+const TXTQuery = (item, productKeys, keepFolderStructure, datestamp) => {
     return new Promise((resolve, reject) => {
         let totalReceived = 0
         let dsl = {
@@ -89,14 +89,11 @@ const CURLQuery = (item, productKeys, keepFolderStructure, datestamp) => {
                         }
 
                         const pdsUri = getPDSUrl(path, release_id)
-                        if (filename && pdsUri)
-                            CURLRows.push(
-                                `curl -sSLO# --create-dirs --output-dir ./pdsimg-atlas-curl_${datestamp}/${filepath} ${pdsUri}\n`
-                            )
+                        if (filename && pdsUri) TXTRows.push(`${pdsUri}\n`)
                     }
                 })
             })
-            if (CURLRows.length > CURL_FILE_MAX_ROWS) createCURLFile(datestamp)
+            if (TXTRows.length > TXT_FILE_MAX_ROWS) createTXTFile(datestamp)
 
             if (totalReceived < item.total) {
                 return axios
@@ -119,7 +116,7 @@ const CURLQuery = (item, productKeys, keepFolderStructure, datestamp) => {
         }
     })
 }
-const CURLImage = (item, productKeys, datestamp) => {
+const TXTImage = (item, productKeys, datestamp) => {
     productKeys.forEach((key) => {
         let path
         if (key === 'src') path = item.uri
@@ -127,27 +124,24 @@ const CURLImage = (item, productKeys, datestamp) => {
         if (path) {
             const filename = getFilename(path)
             const pdsUri = getPDSUrl(path, item.release_id)
-            if (filename && pdsUri)
-                CURLRows.push(
-                    `curl -sSLO# --create-dirs --output-dir ./pdsimg-atlas-curl_${datestamp}/ ${pdsUri}\n`
-                )
+            if (filename && pdsUri) TXTRows.push(`${pdsUri}\n`)
         }
     })
     return
 }
 
-const createCURLFile = (datestamp) => {
-    if (CURLRows.length == 0) {
+const createTXTFile = (datestamp) => {
+    if (TXTRows.length == 0) {
         alert('Nothing to download.')
         return
     }
 
-    let CURLStr = CURLRows.join('')
-    CURLRows = []
+    let TXTStr = TXTRows.join('')
+    TXTRows = []
 
     // Windows treats the % character as EOL in batch files, so need to escape it
-    if (window.navigator.userAgent.indexOf('Windows') !== -1) CURLStr = CURLStr.replace(/%/g, '%%')
+    if (window.navigator.userAgent.indexOf('Windows') !== -1) TXTStr = TXTStr.replace(/%/g, '%%')
 
-    const blob = new Blob([CURLStr], { type: 'text/plain;charset=utf-8' })
-    fileSaver.saveAs(blob, `pdsimg-atlas-curl_${datestamp}.bat`, true)
+    const blob = new Blob([TXTStr], { type: 'text/plain;charset=utf-8' })
+    fileSaver.saveAs(blob, `pdsimg-atlas_${datestamp}.txt`, true)
 }

--- a/src/core/downloaders/TXT.js
+++ b/src/core/downloaders/TXT.js
@@ -11,13 +11,14 @@ const TXT_FILE_MAX_ROWS = 500000
 
 let TXTRows = []
 
-export const TXTCart = (productKeys, datestamp) => {
+export const TXTCart = (statusCallback, finishCallback, setOnStop, productKeys, datestamp) => {
     return (dispatch, getState) => {
         if (productKeys == null || productKeys.length === 0) productKeys = ['src']
 
         const state = getState()
         const cart = state.get('cart').toJS()
         const checkedCart = cart.filter((v) => v.checked === true)
+        const startTime = Date.now()
 
         const tasks = []
 
@@ -26,8 +27,17 @@ export const TXTCart = (productKeys, datestamp) => {
         checkedCart.forEach((d) => {
             tasks.push(async () => {
                 d.type === 'query' || d.type === 'directory' || d.type === 'regex'
-                    ? await TXTQuery(d.item, productKeys, d.type === 'directory', datestamp)
-                    : TXTImage(d.item, productKeys, datestamp)
+                    ? await TXTQuery(
+                          d.item,
+                          productKeys,
+                          d.type === 'directory',
+                          datestamp,
+                          statusCallback,
+                          finishCallback,
+                          setOnStop,
+                          startTime
+                      )
+                    : TXTImage(d.item, productKeys, datestamp, statusCallback)
             })
         })
 
@@ -35,21 +45,53 @@ export const TXTCart = (productKeys, datestamp) => {
             for (const task of tasks) {
                 await task()
             }
-            createTXTFile(datestamp)
+            createTXTFile(datestamp, finishCallback)
         }
 
         callTasks()
     }
 }
 
-const TXTQuery = (item, productKeys, keepFolderStructure, datestamp) => {
+const TXTQuery = (
+    item,
+    productKeys,
+    keepFolderStructure,
+    datestamp,
+    statusCallback,
+    finishCallback,
+    setOnStop,
+    startTime
+) => {
     return new Promise((resolve, reject) => {
         let totalReceived = 0
         let dsl = {
             query: item.query,
-            size: 10000,
-            _source: ['uri', ES_PATHS.related.join('.')],
+            size: 5000,
+            _source: ['uri', ES_PATHS.related.join('.'), ES_PATHS.archive.fs_type.join('.')],
         }
+        let stopped = false
+
+        setOnStop(() => () => {
+            stopped = true
+        })
+
+        sendStatus(
+            statusCallback,
+            null,
+            null,
+            null,
+            null,
+            (totalReceived / item.total) * 100,
+            totalReceived,
+            item.total,
+            item.total,
+            0,
+            Date.now() - startTime,
+            ((Date.now() - startTime) * item.total) / totalReceived - (Date.now() - startTime),
+            0
+        )
+
+        if (keepFolderStructure === true) productKeys = ['src']
 
         const filter_path = 'filter_path=hits.hits._source,hits.total,_scroll_id'
 
@@ -65,18 +107,44 @@ const TXTQuery = (item, productKeys, keepFolderStructure, datestamp) => {
             })
 
         const scroll = (res) => {
-            if (!res?.data?.hits) {
+            if (stopped === true || !res?.data?.hits) {
+                if (typeof finishCallback === 'function') {
+                    finishCallback(false)
+                }
                 reject()
                 return
             }
 
             totalReceived += res.data.hits.hits.length
+            sendStatus(
+                statusCallback,
+                null,
+                null,
+                null,
+                null,
+                (totalReceived / item.total) * 100,
+                totalReceived,
+                item.total,
+                item.total,
+                0,
+                Date.now() - startTime,
+                ((Date.now() - startTime) * item.total) / totalReceived - (Date.now() - startTime),
+                0
+            )
             res.data.hits.hits.forEach((r) => {
                 productKeys.forEach((key) => {
                     let path
                     if (key === 'src') path = getIn(r._source, ES_PATHS.source)
                     else path = getIn(r._source, ES_PATHS.related.concat([key, 'uri']))
                     if (path) {
+                        // Do no try downloading dirs
+                        // Make sure a . exists in the final part
+                        const fs_type = getIn(r._source, ES_PATHS.archive.fs_type)
+                        if (fs_type == null) {
+                            const pathSplit = path.split('/')
+                            if (pathSplit[pathSplit.length - 1].indexOf('.') == null) return
+                        } else if (fs_type === 'directory') return
+
                         const release_id = getIn(r._source, ES_PATHS.release_id)
                         let filename = getFilename(path)
 
@@ -93,7 +161,7 @@ const TXTQuery = (item, productKeys, keepFolderStructure, datestamp) => {
                     }
                 })
             })
-            if (TXTRows.length > TXT_FILE_MAX_ROWS) createTXTFile(datestamp)
+            if (TXTRows.length >= TXT_FILE_MAX_ROWS) createTXTFile(datestamp)
 
             if (totalReceived < item.total) {
                 return axios
@@ -116,8 +184,8 @@ const TXTQuery = (item, productKeys, keepFolderStructure, datestamp) => {
         }
     })
 }
-const TXTImage = (item, productKeys, datestamp) => {
-    productKeys.forEach((key) => {
+const TXTImage = (item, productKeys, datestamp, statusCallback) => {
+    productKeys.forEach((key, idx) => {
         let path
         if (key === 'src') path = item.uri
         else path = getIn(item.related, [key, 'uri'])
@@ -126,11 +194,23 @@ const TXTImage = (item, productKeys, datestamp) => {
             const pdsUri = getPDSUrl(path, item.release_id)
             if (filename && pdsUri) TXTRows.push(`${pdsUri}\n`)
         }
+
+        sendStatus(
+            statusCallback,
+            idx,
+            (idx / productKeys.length) * 100,
+            idx,
+            productKeys.length,
+            (idx / productKeys.length) * 100,
+            idx,
+            productKeys.length,
+            productKeys.length
+        )
     })
     return
 }
 
-const createTXTFile = (datestamp) => {
+const createTXTFile = (datestamp, finishCallback) => {
     if (TXTRows.length == 0) {
         alert('Nothing to download.')
         return
@@ -144,4 +224,33 @@ const createTXTFile = (datestamp) => {
 
     const blob = new Blob([TXTStr], { type: 'text/plain;charset=utf-8' })
     fileSaver.saveAs(blob, `pdsimg-atlas_${datestamp}.txt`, true)
+
+    if (typeof finishCallback === 'function') {
+        finishCallback(false)
+    }
+}
+
+const sendStatus = (cb, ccii, cp, cc, ct, op, oc, ot, otp, ob, oet, oetr, of1) => {
+    // Status
+    const status = {
+        current: {
+            currentItemIdx: ccii != null ? ccii : 0,
+            percent: cp != null ? cp : 100,
+            current: cc != null ? cc : 0,
+            total: ct != null ? ct : 1,
+        },
+        overall: {
+            percent: op != null ? op : 100,
+            current: oc != null ? oc : 0,
+            total: ot != null ? ot : 1,
+            totalProducts: otp != null ? otp : 1,
+            buffer: ob != null ? ob : 0,
+            elapsedTime: oet != null ? oet : 0,
+            estimatedTimeRemaining: oetr != null ? oetr : 0,
+            failures: of1 != null ? of1 : 0,
+        },
+    }
+    if (typeof cb === 'function') {
+        cb(status)
+    }
 }

--- a/src/core/downloaders/WGET.js
+++ b/src/core/downloaders/WGET.js
@@ -11,13 +11,14 @@ const WGET_FILE_MAX_ROWS = 500000
 
 let WGETRows = []
 
-export const WGETCart = (productKeys, datestamp) => {
+export const WGETCart = (statusCallback, finishCallback, setOnStop, productKeys, datestamp) => {
     return (dispatch, getState) => {
         if (productKeys == null || productKeys.length === 0) productKeys = ['src']
 
         const state = getState()
         const cart = state.get('cart').toJS()
         const checkedCart = cart.filter((v) => v.checked === true)
+        const startTime = Date.now()
 
         const tasks = []
 
@@ -26,8 +27,17 @@ export const WGETCart = (productKeys, datestamp) => {
         checkedCart.forEach((d) => {
             tasks.push(async () => {
                 d.type === 'query' || d.type === 'directory' || d.type === 'regex'
-                    ? await WGETQuery(d.item, productKeys, d.type === 'directory', datestamp)
-                    : WGETImage(d.item, productKeys, datestamp)
+                    ? await WGETQuery(
+                          d.item,
+                          productKeys,
+                          d.type === 'directory',
+                          datestamp,
+                          statusCallback,
+                          finishCallback,
+                          setOnStop,
+                          startTime
+                      )
+                    : WGETImage(d.item, productKeys, datestamp, statusCallback)
             })
         })
 
@@ -35,26 +45,58 @@ export const WGETCart = (productKeys, datestamp) => {
             for (const task of tasks) {
                 await task()
             }
-            createWGETFile(datestamp)
+            createWGETFile(datestamp, finishCallback)
         }
 
         callTasks()
     }
 }
 
-const WGETQuery = (item, productKeys, keepFolderStructure, datestamp) => {
+const WGETQuery = (
+    item,
+    productKeys,
+    keepFolderStructure,
+    datestamp,
+    statusCallback,
+    finishCallback,
+    setOnStop,
+    startTime
+) => {
     return new Promise((resolve, reject) => {
         let totalReceived = 0
         let dsl = {
             query: item.query,
-            size: 10000,
-            _source: ['uri', ES_PATHS.related.join('.')],
+            size: 5000,
+            _source: ['uri', ES_PATHS.related.join('.'), ES_PATHS.archive.fs_type.join('.')],
         }
+        let stopped = false
+
+        setOnStop(() => () => {
+            stopped = true
+        })
+
+        sendStatus(
+            statusCallback,
+            null,
+            null,
+            null,
+            null,
+            (totalReceived / item.total) * 100,
+            totalReceived,
+            item.total,
+            item.total,
+            0,
+            Date.now() - startTime,
+            ((Date.now() - startTime) * item.total) / totalReceived - (Date.now() - startTime),
+            0
+        )
+
+        if (keepFolderStructure === true) productKeys = ['src']
 
         const filter_path = 'filter_path=hits.hits._source,hits.total,_scroll_id'
 
         axios
-            .post(`${domain}${endpoints.search}?scroll=1m&${filter_path}`, dsl, getHeader())
+            .post(`${domain}${endpoints.search}?scroll=10m&${filter_path}`, dsl, getHeader())
             .then((res) => scroll(res))
             .then((s) => {
                 resolve()
@@ -65,18 +107,45 @@ const WGETQuery = (item, productKeys, keepFolderStructure, datestamp) => {
             })
 
         const scroll = (res) => {
-            if (!res?.data?.hits) {
+            if (stopped === true || !res?.data?.hits) {
+                if (typeof finishCallback === 'function') {
+                    finishCallback(false)
+                }
                 reject()
                 return
             }
 
             totalReceived += res.data.hits.hits.length
+            sendStatus(
+                statusCallback,
+                null,
+                null,
+                null,
+                null,
+                (totalReceived / item.total) * 100,
+                totalReceived,
+                item.total,
+                item.total,
+                0,
+                Date.now() - startTime,
+                ((Date.now() - startTime) * item.total) / totalReceived - (Date.now() - startTime),
+                0
+            )
             res.data.hits.hits.forEach((r) => {
                 productKeys.forEach((key) => {
                     let path
                     if (key === 'src') path = getIn(r._source, ES_PATHS.source)
                     else path = getIn(r._source, ES_PATHS.related.concat([key, 'uri']))
+
                     if (path) {
+                        // Do no try downloading dirs
+                        // Make sure a . exists in the final part
+                        const fs_type = getIn(r._source, ES_PATHS.archive.fs_type)
+                        if (fs_type == null) {
+                            const pathSplit = path.split('/')
+                            if (pathSplit[pathSplit.length - 1].indexOf('.') == null) return
+                        } else if (fs_type === 'directory') return
+
                         const release_id = getIn(r._source, ES_PATHS.release_id)
                         let filename = getFilename(path)
 
@@ -96,14 +165,14 @@ const WGETQuery = (item, productKeys, keepFolderStructure, datestamp) => {
                     }
                 })
             })
-            if (WGETRows.length > WGET_FILE_MAX_ROWS) createWGETFile(datestamp)
+            if (WGETRows.length >= WGET_FILE_MAX_ROWS) createWGETFile(datestamp)
 
             if (totalReceived < item.total) {
                 return axios
                     .post(
                         `${domain}${endpoints.scroll}?&${filter_path}`,
                         {
-                            scroll: '1m',
+                            scroll: '10m',
                             scroll_id: res.data._scroll_id,
                         },
                         getHeader()
@@ -119,8 +188,8 @@ const WGETQuery = (item, productKeys, keepFolderStructure, datestamp) => {
         }
     })
 }
-const WGETImage = (item, productKeys, datestamp) => {
-    productKeys.forEach((key) => {
+const WGETImage = (item, productKeys, datestamp, statusCallback) => {
+    productKeys.forEach((key, idx) => {
         let path
         if (key === 'src') path = item.uri
         else path = getIn(item.related, [key, 'uri'])
@@ -132,11 +201,23 @@ const WGETImage = (item, productKeys, datestamp) => {
                     `wget -q --show-progress -nc -P ./pdsimg-atlas-wget_${datestamp}/ ${pdsUri}\n`
                 )
         }
+
+        sendStatus(
+            statusCallback,
+            idx,
+            (idx / productKeys.length) * 100,
+            idx,
+            productKeys.length,
+            (idx / productKeys.length) * 100,
+            idx,
+            productKeys.length,
+            productKeys.length
+        )
     })
     return
 }
 
-const createWGETFile = (datestamp) => {
+const createWGETFile = (datestamp, finishCallback) => {
     if (WGETRows.length == 0) {
         alert('Nothing to download.')
         return
@@ -150,4 +231,33 @@ const createWGETFile = (datestamp) => {
 
     const blob = new Blob([WGETStr], { type: 'text/plain;charset=utf-8' })
     fileSaver.saveAs(blob, `pdsimg-atlas-wget_${datestamp}.bat`, true)
+
+    if (typeof finishCallback === 'function') {
+        finishCallback(false)
+    }
+}
+
+const sendStatus = (cb, ccii, cp, cc, ct, op, oc, ot, otp, ob, oet, oetr, of1) => {
+    // Status
+    const status = {
+        current: {
+            currentItemIdx: ccii != null ? ccii : 0,
+            percent: cp != null ? cp : 100,
+            current: cc != null ? cc : 0,
+            total: ct != null ? ct : 1,
+        },
+        overall: {
+            percent: op != null ? op : 100,
+            current: oc != null ? oc : 0,
+            total: ot != null ? ot : 1,
+            totalProducts: otp != null ? otp : 1,
+            buffer: ob != null ? ob : 0,
+            elapsedTime: oet != null ? oet : 0,
+            estimatedTimeRemaining: oetr != null ? oetr : 0,
+            failures: of1 != null ? of1 : 0,
+        },
+    }
+    if (typeof cb === 'function') {
+        cb(status)
+    }
 }

--- a/src/core/downloaders/ZipStream.js
+++ b/src/core/downloaders/ZipStream.js
@@ -112,6 +112,7 @@ const ZipStreamDownload = (
                 // We got next files, so initialize fetching by setting filesIdx from null to 0
                 filesIdx = 0
             }
+
             // Group Failures
             // Skip and recall if something failed
             if (files.length === 0) {

--- a/src/core/redux/store/initial.js
+++ b/src/core/redux/store/initial.js
@@ -19,6 +19,11 @@ if (typeof storageCart === 'string')
     }
 if (!Array.isArray(storageCart)) storageCart = []
 
+// The saved cart checks tremendously annoy me so off they go...
+storageCart.forEach((item) => {
+    if (item.checked === true) item.checked = false
+})
+
 export const INITIAL = (() => {
     return fromJS({
         // ==================== SEARCH RELATED ====================

--- a/src/pages/Cart/Content/Panel/Panel.js
+++ b/src/pages/Cart/Content/Panel/Panel.js
@@ -11,6 +11,8 @@ import Tab from '@material-ui/core/Tab'
 import BrowserTab from './Tabs/Browser/Browser'
 import CURLTab from './Tabs/CURL/CURL'
 import WGETTab from './Tabs/WGET/WGET'
+import CSVTab from './Tabs/CSV/CSV'
+import TXTTab from './Tabs/TXT/TXT'
 
 const useStyles = makeStyles((theme) => ({
     Panel: {
@@ -138,12 +140,16 @@ const Panel = (props) => {
                             <StyledTab label="Browser" />
                             <StyledTab label="WGET" />
                             <StyledTab label="CURL" />
+                            <StyledTab label="CSV" />
+                            <StyledTab label="TXT" />
                         </StyledTabs>
                     </div>
                     <div className={c.tabPanels}>
                         <BrowserTab value={tab} index={0} />
                         <WGETTab value={tab} index={1} />
                         <CURLTab value={tab} index={2} />
+                        <CSVTab value={tab} index={3} />
+                        <TXTTab value={tab} index={4} />
                     </div>
                 </>
             )}

--- a/src/pages/Cart/Content/Panel/Panel.js
+++ b/src/pages/Cart/Content/Panel/Panel.js
@@ -49,10 +49,11 @@ const useStyles = makeStyles((theme) => ({
     },
     introMessage: {
         'position': 'relative',
-        'top': '90px',
-        'width': '238px',
+        'top': '100px',
+        'width': '280px',
         'transform': 'translateY(-50%)',
         'lineHeight': '20px',
+        'fontSize': '16px',
         'color': theme.palette.text.main,
         'background': theme.palette.swatches.yellow.yellow800,
         'margin': theme.spacing(4),
@@ -91,7 +92,7 @@ const StyledTab = withStyles((theme) => ({
         'color': theme.palette.text.main,
         'fontSize': theme.typography.pxToRem(14),
         'marginRight': theme.spacing(1),
-        'minWidth': 88,
+        'minWidth': 58,
         '&:focus': {
             opacity: 1,
         },
@@ -137,7 +138,7 @@ const Panel = (props) => {
                             onChange={handleChange}
                             aria-label="cart download tab"
                         >
-                            <StyledTab label="Browser" />
+                            <StyledTab label="ZIP" />
                             <StyledTab label="WGET" />
                             <StyledTab label="CURL" />
                             <StyledTab label="CSV" />

--- a/src/pages/Cart/Content/Panel/Tabs/Browser/Browser.js
+++ b/src/pages/Cart/Content/Panel/Tabs/Browser/Browser.js
@@ -32,7 +32,7 @@ const useStyles = makeStyles((theme) => ({
     },
     downloading: {
         bottom: '0px',
-        position: 'absolute',
+        position: 'sticky',
         width: '100%',
         padding: '12px',
         boxSizing: 'border-box',
@@ -64,6 +64,15 @@ function BrowserTab(props) {
 
     const dispatch = useDispatch()
     const selectorRef = useRef()
+
+    useEffect(() => {
+        // If true, then it'll next be false
+        if (isDownloading === true && status != null) {
+            const nextStatus = status
+            nextStatus.overall.percent = 100
+            setStatus(nextStatus)
+        }
+    }, [isDownloading])
 
     return (
         <div
@@ -118,7 +127,7 @@ function BrowserTab(props) {
                     <div className={c.downloading}>
                         <div className={clsx(c.error, { [c.errorOn]: error != null })}>{error}</div>
                         <DownloadingCard
-                            downloadId={downloadId}
+                            downloadId={'zip' + downloadId}
                             status={status}
                             controller={zipController}
                             controllerType="zip"

--- a/src/pages/Cart/Content/Panel/Tabs/CSV/CSV.js
+++ b/src/pages/Cart/Content/Panel/Tabs/CSV/CSV.js
@@ -8,7 +8,7 @@ import Button from '@material-ui/core/Button'
 
 import ProductDownloadSelector from '../../../../../../components/ProductDownloadSelector/ProductDownloadSelector'
 import { setSnackBarText } from '../../../../../../core/redux/actions/actions.js'
-import { WGETCart } from '../../../../../../core/downloaders/WGET'
+import { CSVCart } from '../../../../../../core/downloaders/CSV'
 
 import Box from '@material-ui/core/Box'
 
@@ -40,7 +40,7 @@ const useStyles = makeStyles((theme) => ({
     },
 }))
 
-function WGETTab(props) {
+function CSVTab(props) {
     const { value, index, ...other } = props
 
     const c = useStyles()
@@ -51,14 +51,14 @@ function WGETTab(props) {
 
     return (
         <div
-            role="wget-tab"
+            role="csv-tab"
             hidden={value !== index}
-            id={`scrollable-auto-wgettabpanel-${index}`}
+            id={`scrollable-auto-csvtabpanel-${index}`}
             {...other}
         >
             {value === index && (
                 <Box p={3}>
-                    <Typography variant="h5">WGET</Typography>
+                    <Typography variant="h5">CSV</Typography>
                     <Typography className={c.p}>
                         Select the products to include in your download:
                     </Typography>
@@ -66,7 +66,7 @@ function WGETTab(props) {
                     <Button
                         className={c.button1}
                         variant="contained"
-                        aria-label="wget download button"
+                        aria-label="csv download button"
                         onClick={() => {
                             if (selectorRef && selectorRef.current) {
                                 const sel = selectorRef.current.getSelected() || {}
@@ -78,49 +78,25 @@ function WGETTab(props) {
                                         .replace(/:/g, '_')
                                         .replace(/\./g, '_')
                                         .replace(/Z/g, '')
-                                    dispatch(WGETCart(sel, datestamp))
+                                    dispatch(CSVCart(sel, datestamp))
                                     setDatestamp(datestamp)
                                 }
                             }
                         }}
                     >
-                        Download WGET Script
+                        Download CSV
                     </Button>
                     <Typography className={c.p}>
-                        To provide bulk downloading of PDS Imaging products, we have provided a set
-                        of pre-configured WGET commands below that can be executed on your computer
-                        to download the contents of your bulk download cart.
+                        Downloads a .csv named `./pdsimg-atlas_{datestamp}.csv` with the following
+                        header:
                     </Typography>
-                    <Typography className={c.p}>
-                        WGET is software that allows one to download internet content using a
-                        command line interface. Availability and installation of wget varies between
-                        operating systems. Please verify that wget is available for your computer
-                        and is installed.
-                    </Typography>
-                    <Typography className={c.p2}>
-                        After downloading, run the "pdsimg-atlas-wget_{datestamp}.bat" with the
-                        following command:
-                    </Typography>
-                    <Typography className={c.p3}>Mac / Linux:</Typography>
-                    <Typography className={c.pCode}>
-                        source pdsimg-atlas-wget_{datestamp}.bat
-                    </Typography>
-
-                    <Typography className={c.p3}>Windows (WSL):</Typography>
-                    <Typography className={c.pCode}>
-                        bash
-                        <br />
-                        source pdsimg-atlas-wget_{datestamp}.bat
-                    </Typography>
-                    <Typography className={c.p2}>
-                        All files are download into an `./pdsimg-atlas-wget_{datestamp}` directory.
-                    </Typography>
+                    <Typography className={c.pCode}>filename,size,uri,download_url</Typography>
                 </Box>
             )}
         </div>
     )
 }
 
-WGETTab.propTypes = {}
+CSVTab.propTypes = {}
 
-export default WGETTab
+export default CSVTab

--- a/src/pages/Cart/Content/Panel/Tabs/CSV/CSV.js
+++ b/src/pages/Cart/Content/Panel/Tabs/CSV/CSV.js
@@ -5,8 +5,10 @@ import { makeStyles, withStyles } from '@material-ui/core/styles'
 
 import Typography from '@material-ui/core/Typography'
 import Button from '@material-ui/core/Button'
+import clsx from 'clsx'
 
 import ProductDownloadSelector from '../../../../../../components/ProductDownloadSelector/ProductDownloadSelector'
+import DownloadingCard from '../../../../../../components/DownloadingCard/DownloadingCard'
 import { setSnackBarText } from '../../../../../../core/redux/actions/actions.js'
 import { CSVCart } from '../../../../../../core/downloaders/CSV'
 
@@ -38,6 +40,30 @@ const useStyles = makeStyles((theme) => ({
         fontFamily: 'monospace',
         marginBottom: '5px',
     },
+    downloadingButton: {
+        background: theme.palette.swatches.grey.grey300,
+        color: theme.palette.text.primary,
+        pointerEvents: 'none',
+    },
+    downloading: {
+        bottom: '0px',
+        position: 'sticky',
+        width: '100%',
+        padding: '12px',
+        boxSizing: 'border-box',
+    },
+    error: {
+        display: 'none',
+        fontSize: '16px',
+        padding: '12px',
+        background: theme.palette.swatches.red.red500,
+        color: theme.palette.text.secondary,
+        border: `1px solid ${theme.palette.swatches.red.red600}`,
+        textAlign: 'center',
+    },
+    errorOn: {
+        display: 'block',
+    },
 }))
 
 function CSVTab(props) {
@@ -47,7 +73,22 @@ function CSVTab(props) {
     const dispatch = useDispatch()
     const selectorRef = useRef()
 
+    const [isDownloading, setIsDownloading] = useState(false)
+    const [onStop, setOnStop] = useState(false)
+    const [downloadId, setDownloadId] = useState(0)
+    const [status, setStatus] = useState(null)
+    const [error, setError] = useState(null)
+
     const [datestamp, setDatestamp] = useState()
+
+    useEffect(() => {
+        // If true, then it'll next be false
+        if (isDownloading === true && status != null) {
+            const nextStatus = status
+            nextStatus.overall.percent = 100
+            setStatus(nextStatus)
+        }
+    }, [isDownloading])
 
     return (
         <div
@@ -57,41 +98,69 @@ function CSVTab(props) {
             {...other}
         >
             {value === index && (
-                <Box p={3}>
-                    <Typography variant="h5">CSV</Typography>
-                    <Typography className={c.p}>
-                        Select the products to include in your download:
-                    </Typography>
-                    <ProductDownloadSelector ref={selectorRef} />
-                    <Button
-                        className={c.button1}
-                        variant="contained"
-                        aria-label="csv download button"
-                        onClick={() => {
-                            if (selectorRef && selectorRef.current) {
-                                const sel = selectorRef.current.getSelected() || {}
-                                if (sel.length == 0) {
-                                    dispatch(setSnackBarText('Nothing to download', 'warning'))
-                                } else {
-                                    const datestamp = new Date()
-                                        .toISOString()
-                                        .replace(/:/g, '_')
-                                        .replace(/\./g, '_')
-                                        .replace(/Z/g, '')
-                                    dispatch(CSVCart(sel, datestamp))
-                                    setDatestamp(datestamp)
+                <>
+                    <Box p={3}>
+                        <Typography variant="h5">CSV</Typography>
+                        <Typography className={c.p}>
+                            Select the products to include in your download:
+                        </Typography>
+                        <ProductDownloadSelector ref={selectorRef} />
+                        <Button
+                            className={clsx(c.button1, {
+                                [c.downloadingButton]: isDownloading,
+                            })}
+                            variant="contained"
+                            aria-label="csv download button"
+                            onClick={() => {
+                                if (selectorRef && selectorRef.current) {
+                                    const sel = selectorRef.current.getSelected() || {}
+                                    if (sel.length == 0) {
+                                        dispatch(setSnackBarText('Nothing to download', 'warning'))
+                                    } else {
+                                        setIsDownloading(true)
+                                        setDownloadId(downloadId + 1)
+                                        setError(null)
+                                        const datestamp = new Date()
+                                            .toISOString()
+                                            .replace(/:/g, '_')
+                                            .replace(/\./g, '_')
+                                            .replace(/Z/g, '')
+                                        dispatch(
+                                            CSVCart(
+                                                setStatus,
+                                                setIsDownloading,
+                                                setOnStop,
+                                                sel,
+                                                datestamp
+                                            )
+                                        )
+                                        setDatestamp(datestamp)
+                                    }
                                 }
-                            }
-                        }}
-                    >
-                        Download CSV
-                    </Button>
-                    <Typography className={c.p}>
-                        Downloads a .csv named `./pdsimg-atlas_{datestamp}.csv` with the following
-                        header:
-                    </Typography>
-                    <Typography className={c.pCode}>filename,size,uri,download_url</Typography>
-                </Box>
+                            }}
+                        >
+                            {isDownloading ? 'Download in Progress' : 'Download CSV'}
+                        </Button>
+                        <Typography className={c.p}>
+                            Downloads a .csv named `./pdsimg-atlas_{datestamp}.csv` with the
+                            following header:
+                        </Typography>
+                        <Typography className={c.pCode}>filename,size,uri,download_url</Typography>
+                        <Typography className={c.p}>
+                            The downloaded script files max out at 500k lines. Multiple script files
+                            may be downloaded to support to entire payload.
+                        </Typography>
+                    </Box>
+                    <div className={c.downloading}>
+                        <div className={clsx(c.error, { [c.errorOn]: error != null })}>{error}</div>
+                        <DownloadingCard
+                            downloadId={'csv' + downloadId}
+                            status={status}
+                            hidePause={true}
+                            onStop={onStop}
+                        />
+                    </div>
+                </>
             )}
         </div>
     )

--- a/src/pages/Cart/Content/Panel/Tabs/CURL/CURL.js
+++ b/src/pages/Cart/Content/Panel/Tabs/CURL/CURL.js
@@ -5,8 +5,10 @@ import { makeStyles, withStyles } from '@material-ui/core/styles'
 
 import Typography from '@material-ui/core/Typography'
 import Button from '@material-ui/core/Button'
+import clsx from 'clsx'
 
 import ProductDownloadSelector from '../../../../../../components/ProductDownloadSelector/ProductDownloadSelector'
+import DownloadingCard from '../../../../../../components/DownloadingCard/DownloadingCard'
 import { setSnackBarText } from '../../../../../../core/redux/actions/actions.js'
 import { CURLCart } from '../../../../../../core/downloaders/CURL'
 
@@ -38,6 +40,30 @@ const useStyles = makeStyles((theme) => ({
         fontFamily: 'monospace',
         marginBottom: '5px',
     },
+    downloadingButton: {
+        background: theme.palette.swatches.grey.grey300,
+        color: theme.palette.text.primary,
+        pointerEvents: 'none',
+    },
+    downloading: {
+        bottom: '0px',
+        position: 'sticky',
+        width: '100%',
+        padding: '12px',
+        boxSizing: 'border-box',
+    },
+    error: {
+        display: 'none',
+        fontSize: '16px',
+        padding: '12px',
+        background: theme.palette.swatches.red.red500,
+        color: theme.palette.text.secondary,
+        border: `1px solid ${theme.palette.swatches.red.red600}`,
+        textAlign: 'center',
+    },
+    errorOn: {
+        display: 'block',
+    },
 }))
 
 function CURLTab(props) {
@@ -47,7 +73,22 @@ function CURLTab(props) {
     const dispatch = useDispatch()
     const selectorRef = useRef()
 
+    const [isDownloading, setIsDownloading] = useState(false)
+    const [onStop, setOnStop] = useState(false)
+    const [downloadId, setDownloadId] = useState(0)
+    const [status, setStatus] = useState(null)
+    const [error, setError] = useState(null)
+
     const [datestamp, setDatestamp] = useState()
+
+    useEffect(() => {
+        // If true, then it'll next be false
+        if (isDownloading === true && status != null) {
+            const nextStatus = status
+            nextStatus.overall.percent = 100
+            setStatus(nextStatus)
+        }
+    }, [isDownloading])
 
     return (
         <div
@@ -57,66 +98,97 @@ function CURLTab(props) {
             {...other}
         >
             {value === index && (
-                <Box p={3}>
-                    <Typography variant="h5">CURL</Typography>
-                    <Typography className={c.p}>
-                        Select the products to include in your download:
-                    </Typography>
-                    <ProductDownloadSelector ref={selectorRef} />
-                    <Button
-                        className={c.button1}
-                        variant="contained"
-                        aria-label="curl download button"
-                        onClick={() => {
-                            if (selectorRef && selectorRef.current) {
-                                const sel = selectorRef.current.getSelected() || {}
-                                if (sel.length == 0) {
-                                    dispatch(setSnackBarText('Nothing to download', 'warning'))
-                                } else {
-                                    const datestamp = new Date()
-                                        .toISOString()
-                                        .replace(/:/g, '_')
-                                        .replace(/\./g, '_')
-                                        .replace(/Z/g, '')
-                                    dispatch(CURLCart(sel, datestamp))
-                                    setDatestamp(datestamp)
+                <>
+                    <Box p={3}>
+                        <Typography variant="h5">CURL</Typography>
+                        <Typography className={c.p}>
+                            Select the products to include in your download:
+                        </Typography>
+                        <ProductDownloadSelector ref={selectorRef} />
+                        <Button
+                            className={clsx(c.button1, {
+                                [c.downloadingButton]: isDownloading,
+                            })}
+                            variant="contained"
+                            aria-label="curl download button"
+                            onClick={() => {
+                                if (selectorRef && selectorRef.current) {
+                                    const sel = selectorRef.current.getSelected() || {}
+                                    if (sel.length == 0) {
+                                        dispatch(setSnackBarText('Nothing to download', 'warning'))
+                                    } else {
+                                        setIsDownloading(true)
+                                        setDownloadId(downloadId + 1)
+                                        setError(null)
+                                        const datestamp = new Date()
+                                            .toISOString()
+                                            .replace(/:/g, '_')
+                                            .replace(/\./g, '_')
+                                            .replace(/Z/g, '')
+                                        dispatch(
+                                            CURLCart(
+                                                setStatus,
+                                                setIsDownloading,
+                                                setOnStop,
+                                                sel,
+                                                datestamp
+                                            )
+                                        )
+                                        setDatestamp(datestamp)
+                                    }
                                 }
-                            }
-                        }}
-                    >
-                        Download CURL Script
-                    </Button>
-                    <Typography className={c.p2}>Requires: curl 7.73.0+</Typography>
-                    <Typography className={c.p}>
-                        To provide bulk downloading of PDS Imaging products, we have provided a set
-                        of pre-configured CURL commands below that can be executed on your computer
-                        to download the contents of your bulk download cart.
-                    </Typography>
-                    <Typography className={c.p}>
-                        CURL is software that allows one to download internet content using a
-                        command line interface. Availability and installation of Curl varies between
-                        operating systems. Please verify that Curl is available for your computer
-                        and is installed.
-                    </Typography>
-                    <Typography className={c.p2}>
-                        After downloading, run the "pdsimg-atlas-curl_{datestamp}.bat" with the
-                        following command:
-                    </Typography>
-                    <Typography className={c.p3}>Mac / Linux:</Typography>
-                    <Typography className={c.pCode}>
-                        source pdsimg-atlas-curl_{datestamp}.bat
-                    </Typography>
+                            }}
+                        >
+                            {isDownloading ? 'Download in Progress' : 'Download CURL Script'}
+                        </Button>
+                        <Typography className={c.p2}>Requires: curl 7.73.0+</Typography>
+                        <Typography className={c.p}>
+                            To provide bulk downloading of PDS Imaging products, we have provided a
+                            set of pre-configured CURL commands below that can be executed on your
+                            computer to download the contents of your bulk download cart.
+                        </Typography>
+                        <Typography className={c.p}>
+                            CURL is software that allows one to download internet content using a
+                            command line interface. Availability and installation of Curl varies
+                            between operating systems. Please verify that Curl is available for your
+                            computer and is installed.
+                        </Typography>
+                        <Typography className={c.p2}>
+                            After downloading, run the "pdsimg-atlas-curl_{datestamp}.bat" with the
+                            following command:
+                        </Typography>
+                        <Typography className={c.p3}>Mac / Linux:</Typography>
+                        <Typography className={c.pCode}>
+                            source pdsimg-atlas-curl_{datestamp}.bat
+                        </Typography>
 
-                    <Typography className={c.p3}>Windows (WSL):</Typography>
-                    <Typography className={c.pCode}>
-                        bash
-                        <br />
-                        source pdsimg-atlas-curl_{datestamp}.bat
-                    </Typography>
-                    <Typography className={c.p}>
-                        All files are download into an `./pdsimg-atlas-curl_{datestamp}` directory.
-                    </Typography>
-                </Box>
+                        <Typography className={c.p3}>Windows (WSL):</Typography>
+                        <Typography className={c.pCode}>
+                            bash
+                            <br />
+                            source pdsimg-atlas-curl_{datestamp}.bat
+                        </Typography>
+                        <Typography className={c.p}>
+                            The downloaded script files max out at 500k lines. Multiple script files
+                            may be downloaded to support to entire payload.
+                        </Typography>
+                        <Typography className={c.p}>
+                            All files are download into an `./pdsimg-atlas-curl_{datestamp}`
+                            directory.
+                        </Typography>
+                        <div className={c.downloading}>
+                            <div className={clsx(c.error, { [c.errorOn]: error != null })}>
+                                {error}
+                            </div>
+                            <DownloadingCard
+                                downloadId={'curl' + downloadId}
+                                status={status}
+                                hidePause={true}
+                                onStop={onStop}
+                            />
+                        </div>
+                    </Box>
+                </>
             )}
         </div>
     )

--- a/src/pages/Cart/Content/Panel/Tabs/CURL/CURL.js
+++ b/src/pages/Cart/Content/Panel/Tabs/CURL/CURL.js
@@ -7,6 +7,7 @@ import Typography from '@material-ui/core/Typography'
 import Button from '@material-ui/core/Button'
 
 import ProductDownloadSelector from '../../../../../../components/ProductDownloadSelector/ProductDownloadSelector'
+import { setSnackBarText } from '../../../../../../core/redux/actions/actions.js'
 import { CURLCart } from '../../../../../../core/downloaders/CURL'
 
 import Box from '@material-ui/core/Box'
@@ -25,10 +26,17 @@ const useStyles = makeStyles((theme) => ({
         fontWeight: 'bold',
         padding: `${theme.spacing(1.5)}px 0px`,
     },
+    p3: {
+        color: theme.palette.swatches.blue.blue900,
+        padding: `${theme.spacing(1.5)}px 0px`,
+        fontWeight: 'bold',
+        fontSize: '13px',
+    },
     pCode: {
         background: theme.palette.swatches.grey.grey200,
         padding: `${theme.spacing(4)}px`,
         fontFamily: 'monospace',
+        marginBottom: '5px',
     },
 }))
 
@@ -38,6 +46,8 @@ function CURLTab(props) {
     const c = useStyles()
     const dispatch = useDispatch()
     const selectorRef = useRef()
+
+    const [datestamp, setDatestamp] = useState()
 
     return (
         <div
@@ -59,28 +69,53 @@ function CURLTab(props) {
                         aria-label="curl download button"
                         onClick={() => {
                             if (selectorRef && selectorRef.current) {
-                                dispatch(CURLCart(selectorRef.current.getSelected()))
+                                const sel = selectorRef.current.getSelected() || {}
+                                if (sel.length == 0) {
+                                    dispatch(setSnackBarText('Nothing to download', 'warning'))
+                                } else {
+                                    const datestamp = new Date()
+                                        .toISOString()
+                                        .replace(/:/g, '_')
+                                        .replace(/\./g, '_')
+                                        .replace(/Z/g, '')
+                                    dispatch(CURLCart(sel, datestamp))
+                                    setDatestamp(datestamp)
+                                }
                             }
                         }}
                     >
                         Download CURL Script
                     </Button>
+                    <Typography className={c.p2}>Requires: curl 7.73.0+</Typography>
                     <Typography className={c.p}>
                         To provide bulk downloading of PDS Imaging products, we have provided a set
-                        of preconfigured CURL commands below that can be executed on your computer
+                        of pre-configured CURL commands below that can be executed on your computer
                         to download the contents of your bulk download cart.
                     </Typography>
                     <Typography className={c.p}>
                         CURL is software that allows one to download internet content using a
                         command line interface. Availability and installation of Curl varies between
-                        operating systems. Please verify that Curl is avaialable for your computer
+                        operating systems. Please verify that Curl is available for your computer
                         and is installed.
                     </Typography>
                     <Typography className={c.p2}>
-                        After downloading, run the "atlas_curl_script.bat" with the following
-                        command
+                        After downloading, run the "pdsimg-atlas-curl_{datestamp}.bat" with the
+                        following command:
                     </Typography>
-                    <Typography className={c.pCode}>source atlas_curl_script.bat</Typography>
+                    <Typography className={c.p3}>Mac / Linux:</Typography>
+                    <Typography className={c.pCode}>
+                        source pdsimg-atlas-curl_{datestamp}.bat
+                    </Typography>
+
+                    <Typography className={c.p3}>Windows (WSL):</Typography>
+                    <Typography className={c.pCode}>
+                        bash
+                        <br />
+                        source pdsimg-atlas-curl_{datestamp}.bat
+                    </Typography>
+                    <Typography className={c.p}>
+                        All files are download into an `./pdsimg-atlas-curl_{datestamp}` directory.
+                    </Typography>
                 </Box>
             )}
         </div>

--- a/src/pages/Cart/Content/Panel/Tabs/TXT/TXT.js
+++ b/src/pages/Cart/Content/Panel/Tabs/TXT/TXT.js
@@ -8,7 +8,7 @@ import Button from '@material-ui/core/Button'
 
 import ProductDownloadSelector from '../../../../../../components/ProductDownloadSelector/ProductDownloadSelector'
 import { setSnackBarText } from '../../../../../../core/redux/actions/actions.js'
-import { WGETCart } from '../../../../../../core/downloaders/WGET'
+import { TXTCart } from '../../../../../../core/downloaders/TXT'
 
 import Box from '@material-ui/core/Box'
 
@@ -40,7 +40,7 @@ const useStyles = makeStyles((theme) => ({
     },
 }))
 
-function WGETTab(props) {
+function TXTTab(props) {
     const { value, index, ...other } = props
 
     const c = useStyles()
@@ -51,14 +51,14 @@ function WGETTab(props) {
 
     return (
         <div
-            role="wget-tab"
+            role="txt-tab"
             hidden={value !== index}
-            id={`scrollable-auto-wgettabpanel-${index}`}
+            id={`scrollable-auto-txttabpanel-${index}`}
             {...other}
         >
             {value === index && (
                 <Box p={3}>
-                    <Typography variant="h5">WGET</Typography>
+                    <Typography variant="h5">TXT</Typography>
                     <Typography className={c.p}>
                         Select the products to include in your download:
                     </Typography>
@@ -66,7 +66,7 @@ function WGETTab(props) {
                     <Button
                         className={c.button1}
                         variant="contained"
-                        aria-label="wget download button"
+                        aria-label="txt download button"
                         onClick={() => {
                             if (selectorRef && selectorRef.current) {
                                 const sel = selectorRef.current.getSelected() || {}
@@ -78,42 +78,17 @@ function WGETTab(props) {
                                         .replace(/:/g, '_')
                                         .replace(/\./g, '_')
                                         .replace(/Z/g, '')
-                                    dispatch(WGETCart(sel, datestamp))
+                                    dispatch(TXTCart(sel, datestamp))
                                     setDatestamp(datestamp)
                                 }
                             }
                         }}
                     >
-                        Download WGET Script
+                        Download TXT
                     </Button>
                     <Typography className={c.p}>
-                        To provide bulk downloading of PDS Imaging products, we have provided a set
-                        of pre-configured WGET commands below that can be executed on your computer
-                        to download the contents of your bulk download cart.
-                    </Typography>
-                    <Typography className={c.p}>
-                        WGET is software that allows one to download internet content using a
-                        command line interface. Availability and installation of wget varies between
-                        operating systems. Please verify that wget is available for your computer
-                        and is installed.
-                    </Typography>
-                    <Typography className={c.p2}>
-                        After downloading, run the "pdsimg-atlas-wget_{datestamp}.bat" with the
-                        following command:
-                    </Typography>
-                    <Typography className={c.p3}>Mac / Linux:</Typography>
-                    <Typography className={c.pCode}>
-                        source pdsimg-atlas-wget_{datestamp}.bat
-                    </Typography>
-
-                    <Typography className={c.p3}>Windows (WSL):</Typography>
-                    <Typography className={c.pCode}>
-                        bash
-                        <br />
-                        source pdsimg-atlas-wget_{datestamp}.bat
-                    </Typography>
-                    <Typography className={c.p2}>
-                        All files are download into an `./pdsimg-atlas-wget_{datestamp}` directory.
+                        Downloads a .txt file named `./pdsimg-atlas_{datestamp}.txt` that simply
+                        lists out all download urls.
                     </Typography>
                 </Box>
             )}
@@ -121,6 +96,6 @@ function WGETTab(props) {
     )
 }
 
-WGETTab.propTypes = {}
+TXTTab.propTypes = {}
 
-export default WGETTab
+export default TXTTab

--- a/src/pages/Cart/Content/Panel/Tabs/WGET/WGET.js
+++ b/src/pages/Cart/Content/Panel/Tabs/WGET/WGET.js
@@ -5,8 +5,10 @@ import { makeStyles, withStyles } from '@material-ui/core/styles'
 
 import Typography from '@material-ui/core/Typography'
 import Button from '@material-ui/core/Button'
+import clsx from 'clsx'
 
 import ProductDownloadSelector from '../../../../../../components/ProductDownloadSelector/ProductDownloadSelector'
+import DownloadingCard from '../../../../../../components/DownloadingCard/DownloadingCard'
 import { setSnackBarText } from '../../../../../../core/redux/actions/actions.js'
 import { WGETCart } from '../../../../../../core/downloaders/WGET'
 
@@ -38,6 +40,30 @@ const useStyles = makeStyles((theme) => ({
         fontFamily: 'monospace',
         marginBottom: '5px',
     },
+    downloadingButton: {
+        background: theme.palette.swatches.grey.grey300,
+        color: theme.palette.text.primary,
+        pointerEvents: 'none',
+    },
+    downloading: {
+        bottom: '0px',
+        position: 'sticky',
+        width: '100%',
+        padding: '12px',
+        boxSizing: 'border-box',
+    },
+    error: {
+        display: 'none',
+        fontSize: '16px',
+        padding: '12px',
+        background: theme.palette.swatches.red.red500,
+        color: theme.palette.text.secondary,
+        border: `1px solid ${theme.palette.swatches.red.red600}`,
+        textAlign: 'center',
+    },
+    errorOn: {
+        display: 'block',
+    },
 }))
 
 function WGETTab(props) {
@@ -47,7 +73,22 @@ function WGETTab(props) {
     const dispatch = useDispatch()
     const selectorRef = useRef()
 
+    const [isDownloading, setIsDownloading] = useState(false)
+    const [onStop, setOnStop] = useState(false)
+    const [downloadId, setDownloadId] = useState(0)
+    const [status, setStatus] = useState(null)
+    const [error, setError] = useState(null)
+
     const [datestamp, setDatestamp] = useState()
+
+    useEffect(() => {
+        // If true, then it'll next be false
+        if (isDownloading === true && status != null) {
+            const nextStatus = status
+            nextStatus.overall.percent = 100
+            setStatus(nextStatus)
+        }
+    }, [isDownloading])
 
     return (
         <div
@@ -57,65 +98,94 @@ function WGETTab(props) {
             {...other}
         >
             {value === index && (
-                <Box p={3}>
-                    <Typography variant="h5">WGET</Typography>
-                    <Typography className={c.p}>
-                        Select the products to include in your download:
-                    </Typography>
-                    <ProductDownloadSelector ref={selectorRef} />
-                    <Button
-                        className={c.button1}
-                        variant="contained"
-                        aria-label="wget download button"
-                        onClick={() => {
-                            if (selectorRef && selectorRef.current) {
-                                const sel = selectorRef.current.getSelected() || {}
-                                if (sel.length == 0) {
-                                    dispatch(setSnackBarText('Nothing to download', 'warning'))
-                                } else {
-                                    const datestamp = new Date()
-                                        .toISOString()
-                                        .replace(/:/g, '_')
-                                        .replace(/\./g, '_')
-                                        .replace(/Z/g, '')
-                                    dispatch(WGETCart(sel, datestamp))
-                                    setDatestamp(datestamp)
+                <>
+                    <Box p={3}>
+                        <Typography variant="h5">WGET</Typography>
+                        <Typography className={c.p}>
+                            Select the products to include in your download:
+                        </Typography>
+                        <ProductDownloadSelector ref={selectorRef} />
+                        <Button
+                            className={clsx(c.button1, {
+                                [c.downloadingButton]: isDownloading,
+                            })}
+                            variant="contained"
+                            aria-label="wget download button"
+                            onClick={() => {
+                                if (selectorRef && selectorRef.current) {
+                                    const sel = selectorRef.current.getSelected() || {}
+                                    if (sel.length == 0) {
+                                        dispatch(setSnackBarText('Nothing to download', 'warning'))
+                                    } else {
+                                        setIsDownloading(true)
+                                        setDownloadId(downloadId + 1)
+                                        setError(null)
+                                        const datestamp = new Date()
+                                            .toISOString()
+                                            .replace(/:/g, '_')
+                                            .replace(/\./g, '_')
+                                            .replace(/Z/g, '')
+                                        dispatch(
+                                            WGETCart(
+                                                setStatus,
+                                                setIsDownloading,
+                                                setOnStop,
+                                                sel,
+                                                datestamp
+                                            )
+                                        )
+                                        setDatestamp(datestamp)
+                                    }
                                 }
-                            }
-                        }}
-                    >
-                        Download WGET Script
-                    </Button>
-                    <Typography className={c.p}>
-                        To provide bulk downloading of PDS Imaging products, we have provided a set
-                        of pre-configured WGET commands below that can be executed on your computer
-                        to download the contents of your bulk download cart.
-                    </Typography>
-                    <Typography className={c.p}>
-                        WGET is software that allows one to download internet content using a
-                        command line interface. Availability and installation of wget varies between
-                        operating systems. Please verify that wget is available for your computer
-                        and is installed.
-                    </Typography>
-                    <Typography className={c.p2}>
-                        After downloading, run the "pdsimg-atlas-wget_{datestamp}.bat" with the
-                        following command:
-                    </Typography>
-                    <Typography className={c.p3}>Mac / Linux:</Typography>
-                    <Typography className={c.pCode}>
-                        source pdsimg-atlas-wget_{datestamp}.bat
-                    </Typography>
+                            }}
+                        >
+                            {isDownloading ? 'Download in Progress' : 'Download WGET Script'}
+                        </Button>
+                        <Typography className={c.p}>
+                            To provide bulk downloading of PDS Imaging products, we have provided a
+                            set of pre-configured WGET commands below that can be executed on your
+                            computer to download the contents of your bulk download cart.
+                        </Typography>
+                        <Typography className={c.p}>
+                            WGET is software that allows one to download internet content using a
+                            command line interface. Availability and installation of wget varies
+                            between operating systems. Please verify that wget is available for your
+                            computer and is installed.
+                        </Typography>
+                        <Typography className={c.p2}>
+                            After downloading, run the "pdsimg-atlas-wget_{datestamp}.bat" with the
+                            following command:
+                        </Typography>
+                        <Typography className={c.p3}>Mac / Linux:</Typography>
+                        <Typography className={c.pCode}>
+                            source pdsimg-atlas-wget_{datestamp}.bat
+                        </Typography>
 
-                    <Typography className={c.p3}>Windows (WSL):</Typography>
-                    <Typography className={c.pCode}>
-                        bash
-                        <br />
-                        source pdsimg-atlas-wget_{datestamp}.bat
-                    </Typography>
-                    <Typography className={c.p2}>
-                        All files are download into an `./pdsimg-atlas-wget_{datestamp}` directory.
-                    </Typography>
-                </Box>
+                        <Typography className={c.p3}>Windows (WSL):</Typography>
+                        <Typography className={c.pCode}>
+                            bash
+                            <br />
+                            source pdsimg-atlas-wget_{datestamp}.bat
+                        </Typography>
+                        <Typography className={c.p}>
+                            The downloaded script files max out at 500k lines. Multiple script files
+                            may be downloaded to support to entire payload.
+                        </Typography>
+                        <Typography className={c.p}>
+                            All files are downloaded into an `./pdsimg-atlas-wget_{datestamp}`
+                            directory.
+                        </Typography>
+                    </Box>
+                    <div className={c.downloading}>
+                        <div className={clsx(c.error, { [c.errorOn]: error != null })}>{error}</div>
+                        <DownloadingCard
+                            downloadId={'wget' + downloadId}
+                            status={status}
+                            hidePause={true}
+                            onStop={onStop}
+                        />
+                    </div>
+                </>
             )}
         </div>
     )


### PR DESCRIPTION
Closes #23 

![23532543264](https://github.com/NASA-PDS/atlas/assets/25355244/6d279259-bca0-43c3-a921-51fa5ff06e1f)

- Fixes WGET and CURL download scripts for folder
- Running WGET and CURL scripts for a folder download retains the file structure 
- Improves WGET and CURL script to be less verbose and only show progress
- Adds CSV and TXT download options
- Fixes issues when bulk downloading different cart types at the same time (folders, queries, single images, etc.)
- Adds progress indicators for all download types (previously it was only for the ZIP downloads.)
- Add ability to cancel any download.
- Cart checked state is not used from localStorage anymore since it was annoying -- refreshing page will lose cart item checks.
- WGET, CURL, CSV and TXT downloads download in 500k line chunks (due to max string length limits)
- Timestamps are added to downloaded script filenames
