### PR TITLE
#28 Better Handling of Missing Browses

### DIFF
--- a/src/components/OpenSeadragonViewer/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer/OpenSeadragonViewer.js
@@ -307,8 +307,8 @@ const OpenSeadragonViewer = ({ image, settings, features, onLayers }) => {
                                 <div>This product doesn't have a browse image.</div>
                             </div>
                             <div className={c.statusErrorMessage}>
-                                Not all do. That's okay. You can still view the label, download the
-                                source product and add it to the cart.
+                                You can still view the label, download the source product and add it
+                                to the cart.
                             </div>
                         </div>
                     </Paper>

--- a/src/components/OpenSeadragonViewer/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer/OpenSeadragonViewer.js
@@ -75,6 +75,15 @@ const useStyles = makeStyles((theme) => ({
     joiner: {
         borderBottom: '1px solid rgba(0,0,0,0.17)',
     },
+    openFailedWrapper: {
+        opacity: 0,
+        transition: `0.2s ease-in opacity`,
+        pointerEvents: 'none',
+    },
+    openFailedShown: {
+        pointerEvents: 'initial',
+        opacity: 1,
+    },
     status: {
         'position': 'absolute',
 
@@ -92,7 +101,7 @@ const useStyles = makeStyles((theme) => ({
     },
     statusHidden: {
         pointerEvents: 'none',
-        opacity: 0,
+        opacity: 1,
     },
     statusPaper: {
         'position': 'absolute',
@@ -100,14 +109,15 @@ const useStyles = makeStyles((theme) => ({
         'left': '50%',
         'transform': 'translateX(-50%) translateY(-50%)',
         'background': theme.palette.primary.main,
+        'opacity': 0.75,
         '& > div': {
             padding: `${theme.spacing(4)}px ${theme.spacing(6)}px`,
         },
     },
     statusError: {
-        background: theme.palette.swatches.red.red500,
+        background: theme.palette.accent.main,
         fontSize: '16px',
-        color: theme.palette.text.primary,
+        color: theme.palette.text.secondary,
         paddingBottom: theme.spacing(0.5),
     },
     statusErrorTitle: {
@@ -123,7 +133,8 @@ const useStyles = makeStyles((theme) => ({
     statusErrorMessage: {
         textAlign: 'center',
         margin: '0px 5%',
-        maxWidth: '600px',
+        maxWidth: '550px',
+        color: theme.palette.swatches.grey.grey100,
     },
 }))
 
@@ -285,27 +296,24 @@ const OpenSeadragonViewer = ({ image, settings, features, onLayers }) => {
                     </IconButton>
                 </div>
             </div>
-            {openFailed === true ? (
-                <div className={c.openFailedWrapper}>
-                    <div className={clsx(c.status, { [c.statusHidden]: !openFailed })}>
-                        <Paper className={c.statusPaper} elevation={2}>
-                            <div className={c.statusError}>
-                                <div className={c.statusErrorTitle}>
-                                    <Tooltip title={''} arrow placement="left-end">
-                                        <ErrorOutlineOutlinedIcon fontSize="large" />
-                                    </Tooltip>
-                                    <div>This product doesn't seem to have a browse image.</div>
-                                </div>
-                                <div className={c.statusErrorMessage}>
-                                    We encountered an error while trying to search our imaging
-                                    archive, please try again. If the issue persists, please contact
-                                    a site administrator.
-                                </div>
+            <div className={clsx(c.openFailedWrapper, { [c.openFailedShown]: openFailed })}>
+                <div className={clsx(c.status, { [c.statusHidden]: !openFailed })}>
+                    <Paper className={c.statusPaper} elevation={2}>
+                        <div className={c.statusError}>
+                            <div className={c.statusErrorTitle}>
+                                <Tooltip title={''} arrow placement="left-end">
+                                    <ErrorOutlineOutlinedIcon fontSize="large" />
+                                </Tooltip>
+                                <div>This product doesn't have a browse image.</div>
                             </div>
-                        </Paper>
-                    </div>
+                            <div className={c.statusErrorMessage}>
+                                Not all do. That's okay. You can still view the label, download the
+                                source product and add it to the cart.
+                            </div>
+                        </div>
+                    </Paper>
                 </div>
-            ) : null}
+            </div>
         </div>
     )
 }

--- a/src/components/ProductIcons/ProductIcons.js
+++ b/src/components/ProductIcons/ProductIcons.js
@@ -6,7 +6,7 @@ import clsx from 'clsx'
 import { makeStyles, useTheme } from '@material-ui/core/styles'
 import { getExtension } from '../../core/utils'
 
-import BrokenImageIcon from '@material-ui/icons/BrokenImage'
+import ImageIcon from '@material-ui/icons/Image'
 import InsertDriveFileOutlinedIcon from '@material-ui/icons/InsertDriveFileOutlined'
 import FolderIcon from '@material-ui/icons/Folder'
 
@@ -83,6 +83,9 @@ const useStyles = makeStyles((theme) => ({
     dark: {
         color: 'black',
     },
+    missing: {
+        color: theme.palette.accent.main,
+    },
     iconSvg: {
         width: '48px',
         height: '48px',
@@ -106,6 +109,8 @@ const ProductIcons = (props) => {
     const c = useStyles()
 
     let Icon
+
+    let isMissing = false
 
     if (type) {
         switch (type) {
@@ -137,7 +142,8 @@ const ProductIcons = (props) => {
                 Icon = <InsertDriveFileOutlinedIcon className={clsx(c.default)} />
                 break
             default:
-                Icon = <BrokenImageIcon className={clsx(c.default)} />
+                isMissing = true
+                Icon = <ImageIcon className={clsx(c.default)} />
         }
     } else {
         const ext = getExtension(filename, true)
@@ -155,7 +161,8 @@ const ProductIcons = (props) => {
                 )
                 break
             default:
-                Icon = <BrokenImageIcon className={clsx(c.default)} />
+                isMissing = true
+                Icon = <ImageIcon className={clsx(c.default)} />
         }
     }
 
@@ -164,6 +171,7 @@ const ProductIcons = (props) => {
             className={clsx(c.ProductIcons, {
                 [c.small]: size === 'small',
                 [c.dark]: color === 'dark',
+                [c.missing]: isMissing === true,
             })}
         >
             {Icon}

--- a/src/pages/Cart/Content/CartView/CartView.js
+++ b/src/pages/Cart/Content/CartView/CartView.js
@@ -28,6 +28,7 @@ import Tooltip from '@material-ui/core/Tooltip'
 import InsertDriveFileOutlinedIcon from '@material-ui/icons/InsertDriveFileOutlined'
 import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined'
 import FolderIcon from '@material-ui/icons/Folder'
+import ImageIcon from '@material-ui/icons/Image'
 
 import { setRecordData, setSnackBarText } from '../../../../core/redux/actions/actions'
 
@@ -208,6 +209,9 @@ const useStyles = makeStyles((theme) => ({
     noBackground: {
         background: 'none',
     },
+    errorIcon: {
+        fontSize: '42px',
+    },
 }))
 
 const CartView = (props) => {
@@ -370,6 +374,7 @@ const GridCard = ({ index, data, width }) => {
                                 disableSpinner={true}
                                 animationDuration={1200}
                                 iconContainerStyle={{ opacity: 0.6 }}
+                                errorIcon={<ImageIcon className={c.errorIcon} />}
                                 src={imgURL || ''}
                                 alt={imgAlt}
                             />

--- a/src/pages/FileExplorer/Preview/Preview.js
+++ b/src/pages/FileExplorer/Preview/Preview.js
@@ -428,6 +428,7 @@ const Preview = (props) => {
     const [related, setRelated] = useState(null)
     const [versions, setVersions] = useState([])
     const [activeVersion, setActiveVersion] = useState(null)
+    const [hasBrowse, setHasBrowse] = useState(false)
 
     let preview = useSelector((state) => {
         const filexPreview = state.get('filexPreview')
@@ -665,6 +666,12 @@ const Preview = (props) => {
                             src={imageUrl}
                             alt={imageUrl}
                             errorIcon={<ProductIcons filename={imageUrl} type={preview.fs_type} />}
+                            onLoad={() => {
+                                setHasBrowse(true)
+                            }}
+                            onError={() => {
+                                setHasBrowse(false)
+                            }}
                         />
                     ) : (
                         <div className={c.imageless}>
@@ -783,138 +790,155 @@ const Preview = (props) => {
                                             </div>
                                         </li>
                                     )}
-                                    {getIn(related, 'gather.pds_archive.related.browse.uri') && (
-                                        <li>
-                                            <div className={c.relatedGroup}>Browse</div>
-                                            <div className={c.relatedLinks}>
-                                                <Button
-                                                    className={c.relatedButton}
-                                                    size="small"
-                                                    variant="outlined"
-                                                    endIcon={
-                                                        <LaunchIcon className={c.buttonIcon} />
-                                                    }
-                                                    onClick={() => {
-                                                        const uri = getIn(
-                                                            related,
-                                                            'gather.pds_archive.related.browse.uri'
-                                                        )
-                                                        const release_id = getIn(
-                                                            related,
-                                                            ES_PATHS.release_id
-                                                        )
-                                                        if (uri)
-                                                            window.open(
-                                                                getPDSUrl(uri, release_id),
-                                                                '_blank'
+                                    {hasBrowse &&
+                                        getIn(related, 'gather.pds_archive.related.browse.uri') && (
+                                            <li>
+                                                <div className={c.relatedGroup}>Browse</div>
+                                                <div className={c.relatedLinks}>
+                                                    <Button
+                                                        className={c.relatedButton}
+                                                        size="small"
+                                                        variant="outlined"
+                                                        endIcon={
+                                                            <LaunchIcon className={c.buttonIcon} />
+                                                        }
+                                                        onClick={() => {
+                                                            const uri = getIn(
+                                                                related,
+                                                                'gather.pds_archive.related.browse.uri'
                                                             )
-                                                    }}
-                                                >
-                                                    <div className={c.relatedItem}>Full</div>
-                                                </Button>
-                                                <Button
-                                                    className={c.relatedButton}
-                                                    size="small"
-                                                    variant="outlined"
-                                                    endIcon={
-                                                        <LaunchIcon className={c.buttonIcon} />
-                                                    }
-                                                    onClick={() => {
-                                                        const uri = getIn(
-                                                            related,
-                                                            'gather.pds_archive.related.browse.uri'
-                                                        )
-                                                        const release_id = getIn(
-                                                            related,
-                                                            ES_PATHS.release_id
-                                                        )
-                                                        if (uri)
-                                                            window.open(
-                                                                getPDSUrl(uri, release_id, 'lg'),
-                                                                '_blank'
+                                                            const release_id = getIn(
+                                                                related,
+                                                                ES_PATHS.release_id
                                                             )
-                                                    }}
-                                                >
-                                                    <div className={c.relatedItem}>Large</div>
-                                                </Button>
-                                                <Button
-                                                    className={c.relatedButton}
-                                                    size="small"
-                                                    variant="outlined"
-                                                    endIcon={
-                                                        <LaunchIcon className={c.buttonIcon} />
-                                                    }
-                                                    onClick={() => {
-                                                        const uri = getIn(
-                                                            related,
-                                                            'gather.pds_archive.related.browse.uri'
-                                                        )
-                                                        const release_id = getIn(
-                                                            related,
-                                                            ES_PATHS.release_id
-                                                        )
-                                                        if (uri)
-                                                            window.open(
-                                                                getPDSUrl(uri, release_id, 'md'),
-                                                                '_blank'
+                                                            if (uri)
+                                                                window.open(
+                                                                    getPDSUrl(uri, release_id),
+                                                                    '_blank'
+                                                                )
+                                                        }}
+                                                    >
+                                                        <div className={c.relatedItem}>Full</div>
+                                                    </Button>
+                                                    <Button
+                                                        className={c.relatedButton}
+                                                        size="small"
+                                                        variant="outlined"
+                                                        endIcon={
+                                                            <LaunchIcon className={c.buttonIcon} />
+                                                        }
+                                                        onClick={() => {
+                                                            const uri = getIn(
+                                                                related,
+                                                                'gather.pds_archive.related.browse.uri'
                                                             )
-                                                    }}
-                                                >
-                                                    <div className={c.relatedItem}>Medium</div>
-                                                </Button>
-                                                <Button
-                                                    className={c.relatedButton}
-                                                    size="small"
-                                                    variant="outlined"
-                                                    endIcon={
-                                                        <LaunchIcon className={c.buttonIcon} />
-                                                    }
-                                                    onClick={() => {
-                                                        const uri = getIn(
-                                                            related,
-                                                            'gather.pds_archive.related.browse.uri'
-                                                        )
-                                                        const release_id = getIn(
-                                                            related,
-                                                            ES_PATHS.release_id
-                                                        )
-                                                        if (uri)
-                                                            window.open(
-                                                                getPDSUrl(uri, release_id, 'sm'),
-                                                                '_blank'
+                                                            const release_id = getIn(
+                                                                related,
+                                                                ES_PATHS.release_id
                                                             )
-                                                    }}
-                                                >
-                                                    <div className={c.relatedItem}>Small</div>
-                                                </Button>
-                                                <Button
-                                                    className={c.relatedButton}
-                                                    size="small"
-                                                    variant="outlined"
-                                                    endIcon={
-                                                        <LaunchIcon className={c.buttonIcon} />
-                                                    }
-                                                    onClick={() => {
-                                                        const uri = getIn(
-                                                            related,
-                                                            'gather.pds_archive.related.browse.uri'
-                                                        )
-                                                        const release_id = getIn(
-                                                            related,
-                                                            ES_PATHS.release_id
-                                                        )
-                                                        if (uri)
-                                                            window.open(
-                                                                getPDSUrl(uri, release_id, 'xs'),
-                                                                '_blank'
+                                                            if (uri)
+                                                                window.open(
+                                                                    getPDSUrl(
+                                                                        uri,
+                                                                        release_id,
+                                                                        'lg'
+                                                                    ),
+                                                                    '_blank'
+                                                                )
+                                                        }}
+                                                    >
+                                                        <div className={c.relatedItem}>Large</div>
+                                                    </Button>
+                                                    <Button
+                                                        className={c.relatedButton}
+                                                        size="small"
+                                                        variant="outlined"
+                                                        endIcon={
+                                                            <LaunchIcon className={c.buttonIcon} />
+                                                        }
+                                                        onClick={() => {
+                                                            const uri = getIn(
+                                                                related,
+                                                                'gather.pds_archive.related.browse.uri'
                                                             )
-                                                    }}
-                                                >
-                                                    <div className={c.relatedItem}>Tiny</div>
-                                                </Button>
-                                            </div>
-                                        </li>
-                                    )}
+                                                            const release_id = getIn(
+                                                                related,
+                                                                ES_PATHS.release_id
+                                                            )
+                                                            if (uri)
+                                                                window.open(
+                                                                    getPDSUrl(
+                                                                        uri,
+                                                                        release_id,
+                                                                        'md'
+                                                                    ),
+                                                                    '_blank'
+                                                                )
+                                                        }}
+                                                    >
+                                                        <div className={c.relatedItem}>Medium</div>
+                                                    </Button>
+                                                    <Button
+                                                        className={c.relatedButton}
+                                                        size="small"
+                                                        variant="outlined"
+                                                        endIcon={
+                                                            <LaunchIcon className={c.buttonIcon} />
+                                                        }
+                                                        onClick={() => {
+                                                            const uri = getIn(
+                                                                related,
+                                                                'gather.pds_archive.related.browse.uri'
+                                                            )
+                                                            const release_id = getIn(
+                                                                related,
+                                                                ES_PATHS.release_id
+                                                            )
+                                                            if (uri)
+                                                                window.open(
+                                                                    getPDSUrl(
+                                                                        uri,
+                                                                        release_id,
+                                                                        'sm'
+                                                                    ),
+                                                                    '_blank'
+                                                                )
+                                                        }}
+                                                    >
+                                                        <div className={c.relatedItem}>Small</div>
+                                                    </Button>
+                                                    <Button
+                                                        className={c.relatedButton}
+                                                        size="small"
+                                                        variant="outlined"
+                                                        endIcon={
+                                                            <LaunchIcon className={c.buttonIcon} />
+                                                        }
+                                                        onClick={() => {
+                                                            const uri = getIn(
+                                                                related,
+                                                                'gather.pds_archive.related.browse.uri'
+                                                            )
+                                                            const release_id = getIn(
+                                                                related,
+                                                                ES_PATHS.release_id
+                                                            )
+                                                            if (uri)
+                                                                window.open(
+                                                                    getPDSUrl(
+                                                                        uri,
+                                                                        release_id,
+                                                                        'xs'
+                                                                    ),
+                                                                    '_blank'
+                                                                )
+                                                        }}
+                                                    >
+                                                        <div className={c.relatedItem}>Tiny</div>
+                                                    </Button>
+                                                </div>
+                                            </li>
+                                        )}
                                 </ul>
                             </div>
                         </div>

--- a/src/pages/FileExplorer/Preview/Preview.js
+++ b/src/pages/FileExplorer/Preview/Preview.js
@@ -428,7 +428,7 @@ const Preview = (props) => {
     const [related, setRelated] = useState(null)
     const [versions, setVersions] = useState([])
     const [activeVersion, setActiveVersion] = useState(null)
-    const [hasBrowse, setHasBrowse] = useState(false)
+    const [hasBrowse, setHasBrowse] = useState(null)
 
     let preview = useSelector((state) => {
         const filexPreview = state.get('filexPreview')
@@ -651,7 +651,7 @@ const Preview = (props) => {
                             history.push(`${HASH_PATHS.record}?uri=${preview.uri}&back=page`)
                     }}
                 >
-                    {imageUrl != 'null' ? (
+                    {imageUrl != 'null' && hasBrowse !== false ? (
                         <Image
                             className={c.previewImage}
                             style={{
@@ -790,7 +790,7 @@ const Preview = (props) => {
                                             </div>
                                         </li>
                                     )}
-                                    {hasBrowse &&
+                                    {hasBrowse === true &&
                                         getIn(related, 'gather.pds_archive.related.browse.uri') && (
                                             <li>
                                                 <div className={c.relatedGroup}>Browse</div>


### PR DESCRIPTION
Closes #28 

#### Broken link icon in search replaced with a blue image icon:
![atlas-f-browse2](https://github.com/NASA-PDS/atlas/assets/25355244/1fff4c3c-8ae0-4ebb-a723-acab639b1f1f)

#### Friendly message for missing browses for the record page:
![atlas-f-browse1](https://github.com/NASA-PDS/atlas/assets/25355244/05a3d464-4494-4976-824c-6f773d178d2f)

#### Product has no browse, therefore there are no browse links in the related section:
![atlas-f-browse3](https://github.com/NASA-PDS/atlas/assets/25355244/4ad58ed1-1b9c-4f73-b94f-c8316ceedf73)

#### Data Access API/Cloudfront now returns a 404 Not Found when before it returned a 403 Forbidden:
![atlas-f-browse4](https://github.com/NASA-PDS/atlas/assets/25355244/b6dedb48-8ec0-4d0e-a14f-191f91eb92f0)

