### PR TITLE
Integrates Roundup Action for CI and fixes secrets detection

### DIFF
--- a/.github/workflows/secrets-detection.yaml
+++ b/.github/workflows/secrets-detection.yaml
@@ -46,8 +46,10 @@ jobs:
                     # find the secrets in the repository
                     detect-secrets scan --disable-plugin AbsolutePathDetectorExperimental --baseline .secrets.new \
                         --exclude-files '\.secrets..*' \
+                        --exclude-files '\.pre-commit-config\.yaml' \
                         --exclude-files '\.git.*' \
-                        --exclude-files 'target'
+                        --exclude-files 'node_modules' \
+                        --exclude-files 'build'
                        
                     # if there is any difference between the known and newly detected secrets, break the build
                     # Function to compare secrets without listing them

--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -1,0 +1,65 @@
+# 🏃‍♀️ Continuous Integration and Delivery: Stable
+# ===============================================
+#
+# Note: for this workflow to succeed, the following secrets must be installed
+# in the repository:
+#
+# ``ADMIN_GITHUB_TOKEN``
+#     A personal access token of a user with collaborator or better access to
+#     the project repository.
+# ``NPMJS_COM_TOKEN`` — token for npmjs.com. To create such a token, visit
+#     npmjs.com, log in, and go to your profile menu → Access Tokens →
+#     Generate new token → Granual access token, and give it a name, a
+#     description, and an expiration date. Leave the IP ranges empty.
+#     Under Packages, choose Read and Write, then All packages. Don't mess
+#     with Organizations. Then click "Generate token" and save the token
+#     in GitHub's secrets as ``NPMJS_COM_TOKEN``.
+
+
+---
+
+name: 😌 Stable integration & delivery
+
+
+# Driving Event
+# -------------
+#
+# What event starts this workflow: a push of a release tag.
+#
+# For the "glob++" pattern syntax, see https://git.io/JJZQt
+
+on:
+    push:
+        tags:
+            - 'release/*'
+
+
+# What to Do
+# ----------
+#
+# Round up, yee-haw!
+
+jobs:
+    stable-assembly:
+        name: 🐴 Stable Assembly
+        runs-on: ubuntu-latest
+        steps:
+            -
+                name: 💳 Checkout
+                uses: actions/checkout@v2
+                with:
+                    lfs: true
+                    token: ${{secrets.ADMIN_GITHUB_TOKEN}}
+                    fetch-depth: 0
+            -
+                name: 🤠 Roundup
+                uses: NASA-PDS/roundup-action@stable
+                with:
+                    assembly: stable
+                env:
+                    ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
+                    NPMJS_COM_TOKEN: ${{secrets.NPMJS_COM_TOKEN}}
+
+...
+
+# -*- mode: yaml; indent: 4; fill-column: 120; coding: utf-8 -*-

--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -1,0 +1,73 @@
+# 🏃‍♀️ Continuous Integration and Delivery: Unstable
+# =================================================
+#
+# Note: for this workflow to succeed, the following secrets must be installed
+# in the repository (or inherited from the repository's organization):
+#
+# Note: for this workflow to succeed, the following secrets must be installed
+# in the repository:
+#
+# ``ADMIN_GITHUB_TOKEN``
+#     A personal access token of a user with collaborator or better access to
+#     the project repository.
+# ``NPMJS_COM_TOKEN`` — token for npmjs.com. To create such a token, visit
+#     npmjs.com, log in, and go to your profile menu → Access Tokens →
+#     Generate new token → Granual access token, and give it a name, a
+#     description, and an expiration date. Leave the IP ranges empty.
+#     Under Packages, choose Read and Write, then All packages. Don't mess
+#     with Organizations. Then click "Generate token" and save the token
+#     in GitHub's secrets as ``NPMJS_COM_TOKEN``.
+
+
+---
+
+name: 🤪 Unstable integration & delivery
+
+
+# Driving Event
+# -------------
+#
+# What event starts this workflow: a push to ``main``.
+#
+# parlance). For the "glob++" pattern syntax, see https://git.io/JJZQt
+
+on:
+    push:
+        branches:
+             - main
+        paths-ignore:
+            - 'CHANGELOG.md'
+            - 'docs/requirements/**'
+    workflow_dispatch:
+
+
+# What to Do
+# ----------
+#
+# Round up, yee-haw!
+
+jobs:
+    unstable-assembly:
+        name: 🧩 Unstable Assembly
+        if: github.actor != 'pdsen-ci'
+        runs-on: ubuntu-latest
+        steps:
+            -
+                name: 💳 Checkout
+                uses: actions/checkout@v2
+                with:
+                    lfs: true
+                    token: ${{secrets.ADMIN_GITHUB_TOKEN}}
+                    fetch-depth: 0
+            -
+                name: 🤠 Roundup
+                uses: NASA-PDS/roundup-action@stable
+                with:
+                    assembly: unstable
+                env:
+                    ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
+                    NPMJS_COM_TOKEN: ${{secrets.NPMJS_COM_TOKEN}}
+
+...
+
+# -*- mode: yaml; indent: 4; fill-column: 120; coding: utf-8 -*-

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,895 @@
+{
+  "version": "1.4.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AWSSensitiveInfoDetectorExperimental"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "EmailAddressDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "\\.secrets..*",
+        "\\.pre-commit-config\\.yaml",
+        "\\.git.*",
+        "node_modules",
+        "build"
+      ]
+    }
+  ],
+  "results": {
+    "README.md": [
+      {
+        "type": "Email Address",
+        "filename": "README.md",
+        "hashed_secret": "b991e951d6b8fd8213909b8de641f8958064f6be",
+        "is_verified": false,
+        "line_number": 84
+      },
+      {
+        "type": "Email Address",
+        "filename": "README.md",
+        "hashed_secret": "13480ae3a2a8f83f90554e8aa8eb51195425a1f2",
+        "is_verified": false,
+        "line_number": 85
+      }
+    ],
+    "package.json": [
+      {
+        "type": "Email Address",
+        "filename": "package.json",
+        "hashed_secret": "fac2dea9e49a83a2d6ee38c580d1e5358b45efa5",
+        "is_verified": false,
+        "line_number": 103
+      }
+    ],
+    "src/external/react-filter-box-REPO/react-filter-box-mod/package.json": [
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/package.json",
+        "hashed_secret": "23014e7cd8b4e8c06eb24f5079b39b8bfe6d3071",
+        "is_verified": false,
+        "line_number": 33
+      }
+    ],
+    "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts": [
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "cd0b0290bb49f9b5300d4eae2c2124d07ab03223",
+        "is_verified": false,
+        "line_number": 6
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "9c6a564b4c09564a2413e6b3c2b807344bfd2092",
+        "is_verified": false,
+        "line_number": 12
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "1bfb78eadcad65f29312465d149a9eca739fbba9",
+        "is_verified": false,
+        "line_number": 18
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "ff24869f5f04166ae9cf2e4154fd394ec6060bf7",
+        "is_verified": false,
+        "line_number": 24
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "41c1e7cacaebdef9612c25cd98d85c773e0f1007",
+        "is_verified": false,
+        "line_number": 30
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "474082b9bc35c09b34d289a9f0a4c404d7a9fe91",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "b0ad1523bba0e21b0317a9a08ff4ee0b85802eed",
+        "is_verified": false,
+        "line_number": 42
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "e842ef00391592fc2173f03957db9b6b4197b67c",
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "3e6dea268ecf8ab0aa0ba527c14b00b8427bc397",
+        "is_verified": false,
+        "line_number": 54
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "103450f57a751fcecf6e1daf3429b00ac1c8cde0",
+        "is_verified": false,
+        "line_number": 60
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "7ec57e52ba03ea7bbd8ee41c6450b13ab0db51a0",
+        "is_verified": false,
+        "line_number": 66
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "eef415404bb3760e1e69596480b966f083a5044b",
+        "is_verified": false,
+        "line_number": 72
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "6f6b4029e33a50eaa663a4822e396273c2afc89b",
+        "is_verified": false,
+        "line_number": 78
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "3e02984c5ddabac76d3dfb09f5aa134dcfc133e5",
+        "is_verified": false,
+        "line_number": 84
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "a729a81cbdf6627f7b5a5034785a84b4e38b49c0",
+        "is_verified": false,
+        "line_number": 90
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "15dcbed7066851794c35e55a940dfc96dd071bc2",
+        "is_verified": false,
+        "line_number": 96
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "b80ec38c885d272461a37006cc8620a92599ed5e",
+        "is_verified": false,
+        "line_number": 102
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "bfeda0997321c1d149bcf072f563f46ae3832c01",
+        "is_verified": false,
+        "line_number": 108
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "e14c5fa802a02f5d0008dac1f3ac3f6aeda65837",
+        "is_verified": false,
+        "line_number": 114
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "a95cb157212e16530cdcf643e4e7f30c93309656",
+        "is_verified": false,
+        "line_number": 120
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "d32ab98fc7812f79009f745fed7a68e4a153781b",
+        "is_verified": false,
+        "line_number": 126
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "c257ec74be78f0f3a0fdb20ba834c2c7a45d3064",
+        "is_verified": false,
+        "line_number": 132
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "8b402014ebc325bd3ed3eb4728431972526f29ab",
+        "is_verified": false,
+        "line_number": 138
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "b80eb8c654f94254e50e2925112b763db0a7cf71",
+        "is_verified": false,
+        "line_number": 144
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "cbfe4faf574e4c89e74418a72b6e7675f5605b2a",
+        "is_verified": false,
+        "line_number": 150
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "0ca09743beeddf1a852bcf11642ef2bd699c3358",
+        "is_verified": false,
+        "line_number": 156
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "9ea742fe874e29175f187ef508e81f52f0c4a789",
+        "is_verified": false,
+        "line_number": 162
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "636e3d39fec397cbec3ca52ee32ffeecd1d61564",
+        "is_verified": false,
+        "line_number": 168
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "6c735c8b3c6df97548895fe76977862810a9e87b",
+        "is_verified": false,
+        "line_number": 174
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "2aabfed2b2fd683d11b4bb4103afd0ac1462944f",
+        "is_verified": false,
+        "line_number": 180
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "5422db273fbcc2a89d27a92a8a653cb1060b2d4c",
+        "is_verified": false,
+        "line_number": 186
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "e84ecdd4f5a8a7394d6f19f6ff0ed52c1641de58",
+        "is_verified": false,
+        "line_number": 192
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "449b987168ae28aaaa01a1dc1bc54d7f49e9c9ef",
+        "is_verified": false,
+        "line_number": 198
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "053bf2557dcc658eb5ee91233c11f1f091653522",
+        "is_verified": false,
+        "line_number": 204
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "82dc6f66061d430440aac4536a39163965edad24",
+        "is_verified": false,
+        "line_number": 210
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "88d5b3e1adccb753b665d55a77f2c8e4737a63b8",
+        "is_verified": false,
+        "line_number": 216
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "f1ec71759ee156991393f10e650c4d32b1e18e52",
+        "is_verified": false,
+        "line_number": 222
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "e55c6dee86984ed6c8d99cdf380537841a746377",
+        "is_verified": false,
+        "line_number": 228
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "b8a8cdadf16dd03ec95bd5ef9f1398f9414be5ec",
+        "is_verified": false,
+        "line_number": 234
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "0e9543155cedb216861fa82dd6a4c9e94f442a35",
+        "is_verified": false,
+        "line_number": 240
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "d6c599cbc08d47de2d1f9ab73e2767a2139d96d2",
+        "is_verified": false,
+        "line_number": 246
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "abae0afc17f1111aedf1c62a435fe5d1a877bd3d",
+        "is_verified": false,
+        "line_number": 252
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "3734b4de69e9ea338362faaea9fba5c95adbefa7",
+        "is_verified": false,
+        "line_number": 258
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "949292cb09a2521c1ee8621c1a57666df2f8578e",
+        "is_verified": false,
+        "line_number": 264
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "d6b526dcc7bc341d920287afc2f034f539d23832",
+        "is_verified": false,
+        "line_number": 270
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "6137bcc1d20c80613fd2b2a49973bbe7e1c5e25b",
+        "is_verified": false,
+        "line_number": 276
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "6d633538c49c54d1b7b81c1f735e4a2f6874e55e",
+        "is_verified": false,
+        "line_number": 282
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "39d84d82b8d166b96e0706788b016a8c35da1c3d",
+        "is_verified": false,
+        "line_number": 288
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "787481e8a35be446fe89ed44ca1355ed2f285d71",
+        "is_verified": false,
+        "line_number": 294
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "bced66b67e14135d327ea0c41c551b315935fe17",
+        "is_verified": false,
+        "line_number": 300
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "ccce25197a3a112307db90f77591fce2848346bd",
+        "is_verified": false,
+        "line_number": 306
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "fb4a2d80d04a9b799ba6a53ac9fdf678229b084f",
+        "is_verified": false,
+        "line_number": 312
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "5d43e1d1462cb16ebce346acbbdc29b6afc29293",
+        "is_verified": false,
+        "line_number": 318
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "3efbfbeb03aab7f84260f54c905d10b0a32044df",
+        "is_verified": false,
+        "line_number": 324
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "93a511252eed3bc70eee88fae09e54f3c6d4b986",
+        "is_verified": false,
+        "line_number": 330
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "cfaac5fa7ace77a4ff81161faa96713a90f7a8c4",
+        "is_verified": false,
+        "line_number": 336
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "1a4b071a866d6b61176fd917ffec77cd9f62d115",
+        "is_verified": false,
+        "line_number": 342
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "0f11cea2d0752cd98236ec4d5dc16b9a3da4be72",
+        "is_verified": false,
+        "line_number": 348
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "d4f1ca6d3cfde516e54c780af706a66a7727847c",
+        "is_verified": false,
+        "line_number": 354
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "8465294b16d4753f283eebcb55f4fdfc098418af",
+        "is_verified": false,
+        "line_number": 360
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "2950734a2ccdadd35f9401ad8452636779c94559",
+        "is_verified": false,
+        "line_number": 366
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "226fd6f1f9ec44cfef8f23db20ce4b8e91bfbae2",
+        "is_verified": false,
+        "line_number": 372
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "24ca9621b19a6814c3d49f04bd5bd154d0b7936e",
+        "is_verified": false,
+        "line_number": 378
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "8f5da5e06c3cea00c664642fc2642b22307a5f42",
+        "is_verified": false,
+        "line_number": 384
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "1f1320be75ac14bc0f74a7e5c8bec418b3e47c9b",
+        "is_verified": false,
+        "line_number": 390
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "73cdf80a1869990a5ff05d1a6ffbdfb5d88c3476",
+        "is_verified": false,
+        "line_number": 396
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "70cab65da026e2275aa619be36a2df6106250d6a",
+        "is_verified": false,
+        "line_number": 402
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "d4352317b2101682adb708757f7ce27743f27fc8",
+        "is_verified": false,
+        "line_number": 408
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "de553b218299a8739c4b1cd7763ba9c02e66e7bf",
+        "is_verified": false,
+        "line_number": 414
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "1f64f9646ed94e64cf2b3ca5702a804c77eec37a",
+        "is_verified": false,
+        "line_number": 420
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "0ea759ab90dd8a7fa931760e1da23c683d7059c8",
+        "is_verified": false,
+        "line_number": 426
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "ff49af62c4b2801b4a53d1ba86cbebd6bf800f0e",
+        "is_verified": false,
+        "line_number": 432
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "122d00edabef67054ffa85fa2e8d14962e253f9c",
+        "is_verified": false,
+        "line_number": 438
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "5aea4afeeb8224e156038a6d81ea09d804032f21",
+        "is_verified": false,
+        "line_number": 444
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "b78e4b5fd1503d49006b859ad23f2f01774faa34",
+        "is_verified": false,
+        "line_number": 450
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "75b9f67217eb844a6084cdc2135b2c9d0436000a",
+        "is_verified": false,
+        "line_number": 456
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "2df55e6cc501262d805206ecb12880cfc2a66a8d",
+        "is_verified": false,
+        "line_number": 462
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "a56784461709a687dad9e2355b5faf142711621f",
+        "is_verified": false,
+        "line_number": 468
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "0c1c1b6d92bc85a340605c8a597df76e303280ef",
+        "is_verified": false,
+        "line_number": 474
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "f80f0bbe2f7237a8ae57e48597036934658c735e",
+        "is_verified": false,
+        "line_number": 480
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "fba89bd843d690dc9c392571d3e186020d6b134c",
+        "is_verified": false,
+        "line_number": 486
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "3d2793750eea833d1fad5ed4af703281bcc756a0",
+        "is_verified": false,
+        "line_number": 492
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "542a4d0366e36589ce3f8f6596269ad8fe1cb189",
+        "is_verified": false,
+        "line_number": 498
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "cfec4e1c8f346611cbd8e8ce0c33144a6ee5de65",
+        "is_verified": false,
+        "line_number": 504
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "cfeb4dfc91cc18c02053b343cc7d0f9af895a68c",
+        "is_verified": false,
+        "line_number": 510
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "2c6ea2fbea145280401dac7a116e3fb073c573b6",
+        "is_verified": false,
+        "line_number": 516
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "a88c75305836a661647bcfc398bbd19a48c22435",
+        "is_verified": false,
+        "line_number": 522
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "f531d81d1baa15e9d6cd1cc2c8c5994f7552cd70",
+        "is_verified": false,
+        "line_number": 528
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "db8df1bbff9a5aff99d65b4dffa1434bd26b418e",
+        "is_verified": false,
+        "line_number": 534
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "df112007ebe928fca0689ca588eec85f5a13af3a",
+        "is_verified": false,
+        "line_number": 540
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "c650765e501e48fd1609fc68ca5e20521820b005",
+        "is_verified": false,
+        "line_number": 546
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "34cbbd6cf072d138764a89f6687ad836b38138f2",
+        "is_verified": false,
+        "line_number": 552
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "b99c322d0114585914c0072b68db0159a6479626",
+        "is_verified": false,
+        "line_number": 558
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "bc3d9e8f960e9fdc444848a3303405735f2b997f",
+        "is_verified": false,
+        "line_number": 564
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "be54f8ba7eea21cab15e18c2e7cdbf8c44f31e4e",
+        "is_verified": false,
+        "line_number": 570
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "3c8fe687fab57af4bec0d340f06c329ff25ca332",
+        "is_verified": false,
+        "line_number": 576
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "91ca93e162a1ae24c4ab39ab8ba7fb9f519aac48",
+        "is_verified": false,
+        "line_number": 582
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "a2a2beef9fafaad0ca0f879d797783723b7898b6",
+        "is_verified": false,
+        "line_number": 588
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "8166cde74de57efba19c0dfeffa9cac321070e6d",
+        "is_verified": false,
+        "line_number": 594
+      },
+      {
+        "type": "Email Address",
+        "filename": "src/external/react-filter-box-REPO/react-filter-box-mod/src/example/data.ts",
+        "hashed_secret": "2aa860b05b93be5de707be192c65200098729bb3",
+        "is_verified": false,
+        "line_number": 600
+      }
+    ],
+    "src/external/streamsaver-helpers/Blob.js": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/external/streamsaver-helpers/Blob.js",
+        "hashed_secret": "1d278d3c888d1a2fa7eed622bfc02927ce4049af",
+        "is_verified": false,
+        "line_number": 264
+      }
+    ],
+    "src/media/fonts/Inter/OFL.txt": [
+      {
+        "type": "Email Address",
+        "filename": "src/media/fonts/Inter/OFL.txt",
+        "hashed_secret": "ef9081347f3f734b962b5f44e2e1add5d325a3cd",
+        "is_verified": false,
+        "line_number": 1
+      }
+    ],
+    "src/pages/FileExplorer/Modals/RegexModal/RegexModal.js": [
+      {
+        "type": "Email Address",
+        "filename": "src/pages/FileExplorer/Modals/RegexModal/RegexModal.js",
+        "hashed_secret": "9362a957c3c70b8c399d621239aca15c132bb0d1",
+        "is_verified": false,
+        "line_number": 625
+      }
+    ]
+  },
+  "generated_at": "2024-04-30T17:32:06Z"
+}


### PR DESCRIPTION
## 🗒️ Summary

Merge this to add Roundup-based continuous integration to the Node.js template repository. As a free bonus, this'll also fix secrets detection:

- Detection workflow was for Java, not Node.js—now it is
- Secrets baseline was missing—now provided

## ⚙️ Test Data and/or Report

See the [sandbox's Node.js repository for past successes](https://github.com/nasa-pds-engineering-node/essence/actions).

Note that the 2 "Node.js CI / build" checks below are orthogonal to this.

## ♻️ Related Issues

- [devops#73](https://github.com/NASA-PDS/devops/issues/73)
