### PR TITLE
#62 Fix added checked results to cart

### DIFF
--- a/src/components/ProductDownloadSelector/ProductDownloadSelector.js
+++ b/src/components/ProductDownloadSelector/ProductDownloadSelector.js
@@ -132,6 +132,8 @@ const ProductDownloadSelector = forwardRef((props, ref) => {
                     if (related[productType]) {
                         if (related[productType].value != null) {
                             size += related[productType].value
+                        } else if (related[productType].size != null) {
+                            size += related[productType].size
                         } else {
                             sizeComplete = false
                         }

--- a/src/components/ProductToolbar/ProductToolbar.js
+++ b/src/components/ProductToolbar/ProductToolbar.js
@@ -168,7 +168,7 @@ const ProductToolbar = (props) => {
               }
           }).length > 0
 
-    if (isInCart) {
+    if (isCart && isInCart) {
         uri = getIn(result, 'item.uri', null)
         release_id = getIn(result, 'item.release_id', null)
     }
@@ -244,10 +244,15 @@ const ProductToolbar = (props) => {
                         size="small"
                         onClick={() => {
                             if (!isInCart) {
+                                const related = getIn(s, ES_PATHS.related)
+                                related.src = related.src || {}
+                                related.src.size = getIn(s, ES_PATHS.archive.size)
+                                related.src.uri = getIn(s, ES_PATHS.uri)
+
                                 dispatch(
                                     addToCart('image', {
                                         uri: getIn(s, ES_PATHS.source),
-                                        related: getIn(s, ES_PATHS.related),
+                                        related: related,
                                         release_id: getIn(s, ES_PATHS.release_id),
                                     })
                                 )

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -28,8 +28,12 @@ export const localStorageCart = 'ATLAS_CART'
 
 export const ES_PATHS = {
     source: ['uri'],
+    uri: ['uri'],
     release_id: ['release_id_num'],
+    gather: ['gather'],
+    gather_uri: ['gather', 'uri'],
     related: ['gather', 'pds_archive', 'related'],
+    pds_archive: ['gather', 'pds_archive'],
     ml: ['gather', 'machine_learning'],
     ml_classification_related: ['gather', 'machine_learning', 'classification', 'related'],
     supplemental: ['gather', 'pds_archive', 'related', 'supplemental'],

--- a/src/core/redux/actions/actions.js
+++ b/src/core/redux/actions/actions.js
@@ -694,7 +694,13 @@ export const search = (page, filtersNeedUpdate, pageNeedsUpdate, url, forceActiv
                 field: 'uri',
             },
             track_total_hits: true,
-            _source: ['uri', 'gather', ES_PATHS.release_id.join('.')],
+            _source: [
+                ES_PATHS.uri.join('.'),
+                ES_PATHS.gather_uri.join('.'),
+                ES_PATHS.pds_archive.join('.'),
+                ES_PATHS.release_id.join('.'),
+                ES_PATHS.archive.size.join('.'),
+            ],
         }
 
         lastDSL = dsl
@@ -706,8 +712,17 @@ export const search = (page, filtersNeedUpdate, pageNeedsUpdate, url, forceActiv
                 const urlHasQuery = url != null ? Object.keys(url.query).length > 0 : false
                 if (!urlHasQuery) {
                     let cartImages = []
-                    for (let i = 0; i < 4 && i < response.data.hits.hits.length; i++)
-                        cartImages.push(getIn(response.data.hits.hits[i]._source, ES_PATHS.thumb))
+                    for (let i = 0; i < 4 && i < response.data.hits.hits.length; i++) {
+                        const release_id = getIn(
+                            response.data.hits.hits[i]._source,
+                            ES_PATHS.release_id
+                        )
+                        cartImages.push(
+                            `${getIn(response.data.hits.hits[i]._source, ES_PATHS.thumb)}${
+                                release_id != null && release_id != 0 ? `::${release_id}` : ''
+                            }`
+                        )
+                    }
 
                     const resultsTotal = getIn(response, 'data.hits.total.value')
                     dispatch({

--- a/src/core/redux/reducers/reducers.js
+++ b/src/core/redux/reducers/reducers.js
@@ -633,15 +633,15 @@ function addToCart(state, payload) {
     let currentCart = state.getIn(['cart']).toJS()
 
     const time = new Date().getTime()
-
     if (payload.item === 'lastQuery') {
         const lastQuery = state.getIn(['lastQuery'])
-        if (lastQuery)
+        if (lastQuery) {
             currentCart.push({
                 type: payload.type,
                 time: time,
                 item: { ...lastQuery.toJS(), ...{ related: payload.aggs } },
             })
+        }
     } else if (payload.item === 'lastRegexQuery') {
         const lastQuery = state.getIn(['lastRegexQuery'])
         if (lastQuery)
@@ -654,15 +654,23 @@ function addToCart(state, payload) {
         const resultKeysChecked = state.getIn(['resultKeysChecked']).toJS()
         const results = state.getIn(['results'])
         results.forEach((r) => {
-            if (resultKeysChecked.includes(r.result_key))
-                currentCart.push({
+            if (resultKeysChecked.includes(r.result_key)) {
+                const item = {
                     type: 'image',
                     time: time,
                     item: {
                         uri: getIn(r._source, ES_PATHS.source),
                         related: getIn(r._source, ES_PATHS.related),
                     },
-                })
+                }
+                item.item.related.src = {
+                    uri: getIn(r._source, ES_PATHS.uri),
+                    size: getIn(r._source, ES_PATHS.archive.size),
+                }
+                item.item.release_id = getIn(r._source, ES_PATHS.release_id)
+
+                currentCart.push(item)
+            }
         })
     } else currentCart.push({ type: payload.type, time: time, item: payload.item })
 


### PR DESCRIPTION
Closes #62

Fixes:
- Possibility of downloading the source products when adding selected images to the cart.
- Fixes download size counts for `individual-image` and `query` items in the cart.
- Fixes the missing release_ids on the preview images of `query` items in the cart.
- Fixes the issue where on the Search page, the middle download icon is removed from a product's hover-over toolbar if the item is also in the cart.
- Also search queries more aggressively use _source to return the minimal fields needed.