### PR TITLE
#63 Improve usability around triggering bulk downloads

### DIFF
--- a/src/components/ProductDownloadSelector/ProductDownloadSelector.js
+++ b/src/components/ProductDownloadSelector/ProductDownloadSelector.js
@@ -47,7 +47,7 @@ const useStyles = makeStyles((theme) => ({
 }))
 
 const ProductDownloadSelector = forwardRef((props, ref) => {
-    const { hidden, forceAllSelected, onSummaryReady } = props
+    const { hidden, forceAllSelected, onSummaryReady, onSelection } = props
 
     const dispatch = useDispatch()
 
@@ -103,16 +103,7 @@ const ProductDownloadSelector = forwardRef((props, ref) => {
 
     useImperativeHandle(ref, () => ({
         getSelected: () => {
-            const selected = []
-            Object.keys(listState).forEach((groupName) => {
-                Object.keys(listState[groupName]).forEach((productType) => {
-                    const p = listState[groupName][productType]
-                    if (p.checked) {
-                        selected.push(productType)
-                    }
-                })
-            })
-            return selected
+            return getSelected(listState)
         },
         getSummary: () => {
             return getSummary(listState)
@@ -163,6 +154,8 @@ const ProductDownloadSelector = forwardRef((props, ref) => {
             !getIn(nextListState, [group, name, 'checked'], false)
         )
         setListState(nextListState)
+        if (typeof onSelection === 'function')
+            onSelection((getSelected(nextListState) || []).length)
     }
 
     const summary = getSummary(listState)
@@ -225,6 +218,19 @@ function makeSelectors(state, onCheck) {
     })
 
     return list
+}
+
+function getSelected(listState) {
+    const selected = []
+    Object.keys(listState).forEach((groupName) => {
+        Object.keys(listState[groupName]).forEach((productType) => {
+            const p = listState[groupName][productType]
+            if (p.checked) {
+                selected.push(productType)
+            }
+        })
+    })
+    return selected
 }
 
 function getSummary(state) {

--- a/src/core/downloaders/CSV.js
+++ b/src/core/downloaders/CSV.js
@@ -222,7 +222,7 @@ const CSVImage = (item, productKeys, datestamp, statusCallback) => {
 
 const createCSVFile = (datestamp, finishCallback) => {
     if (CSVRows.length == 0) {
-        alert('Nothing to download.')
+        alert('Please select products to download.')
         return
     }
 

--- a/src/core/downloaders/CURL.js
+++ b/src/core/downloaders/CURL.js
@@ -224,7 +224,7 @@ const CURLImage = (item, productKeys, datestamp, statusCallback) => {
 
 const createCURLFile = (datestamp) => {
     if (CURLRows.length == 0) {
-        alert('Nothing to download.')
+        alert('Please select products to download.')
         return
     }
 

--- a/src/core/downloaders/TXT.js
+++ b/src/core/downloaders/TXT.js
@@ -218,7 +218,7 @@ const TXTImage = (item, productKeys, datestamp, statusCallback) => {
 
 const createTXTFile = (datestamp, finishCallback) => {
     if (TXTRows.length == 0) {
-        alert('Nothing to download.')
+        alert('Please select products to download.')
         return
     }
 

--- a/src/core/downloaders/WGET.js
+++ b/src/core/downloaders/WGET.js
@@ -225,7 +225,7 @@ const WGETImage = (item, productKeys, datestamp, statusCallback) => {
 
 const createWGETFile = (datestamp, finishCallback) => {
     if (WGETRows.length == 0) {
-        alert('Nothing to download.')
+        alert('Please select products to download.')
         return
     }
 

--- a/src/pages/Cart/Content/MobileDownloadBar/MobileDownloadBar.js
+++ b/src/pages/Cart/Content/MobileDownloadBar/MobileDownloadBar.js
@@ -142,9 +142,13 @@ const MobileDownloadBar = (props) => {
                         onClick={() => {
                             if (selectorRef && selectorRef.current) {
                                 const sel = selectorRef.current.getSelected() || []
-                                const summary = selectorRef.current.getSummary()
                                 if (sel.length == 0) {
-                                    dispatch(setSnackBarText('Nothing to download', 'warning'))
+                                    dispatch(
+                                        setSnackBarText(
+                                            'Please select products to download',
+                                            'warning'
+                                        )
+                                    )
                                 } else {
                                     setIsDownloading(true)
                                     setDownloadId(downloadId + 1)

--- a/src/pages/Cart/Content/Panel/Tabs/Browser/Browser.js
+++ b/src/pages/Cart/Content/Panel/Tabs/Browser/Browser.js
@@ -8,6 +8,7 @@ import clsx from 'clsx'
 import Typography from '@material-ui/core/Typography'
 import Button from '@material-ui/core/Button'
 import Box from '@material-ui/core/Box'
+import Tooltip from '@material-ui/core/Tooltip'
 
 import { ZipStreamCart } from '../../../../../../core/downloaders/ZipStream'
 import { setSnackBarText } from '../../../../../../core/redux/actions/actions.js'
@@ -61,6 +62,7 @@ function BrowserTab(props) {
     const [status, setStatus] = useState(null)
     const [zipController, setZipController] = useState(null)
     const [error, setError] = useState(null)
+    const [selectionCount, setSelectionCount] = useState(0)
 
     const dispatch = useDispatch()
     const selectorRef = useRef()
@@ -88,41 +90,56 @@ function BrowserTab(props) {
                         <Typography className={clsx(c.p, c.subtitle)}>
                             Select the products to include in your download:
                         </Typography>
-                        <ProductDownloadSelector ref={selectorRef} />
-                        <Button
-                            className={clsx(c.button1, {
-                                [c.downloadingButton]: isDownloading,
-                            })}
-                            variant="contained"
-                            aria-label="browser zip download button"
-                            onClick={() => {
-                                if (selectorRef && selectorRef.current) {
-                                    const sel = selectorRef.current.getSelected() || []
-                                    const summary = selectorRef.current.getSummary()
-                                    if (sel.length == 0) {
-                                        dispatch(setSnackBarText('Nothing to download', 'warning'))
-                                    } else {
-                                        setIsDownloading(true)
-                                        setDownloadId(downloadId + 1)
-                                        setError(null)
-                                        dispatch(
-                                            ZipStreamCart(
-                                                setStatus,
-                                                setIsDownloading,
-                                                setZipController,
-                                                sel,
-                                                (err) => {
-                                                    setError(err)
-                                                    setIsDownloading(false)
-                                                }
-                                            )
-                                        )
-                                    }
-                                }
-                            }}
+                        <ProductDownloadSelector
+                            ref={selectorRef}
+                            onSelection={setSelectionCount}
+                        />
+                        <Tooltip
+                            title={selectionCount === 0 ? 'Select products above to download.' : ''}
+                            arrow
                         >
-                            {isDownloading ? 'Download in Progress' : 'Download ZIP'}
-                        </Button>
+                            <span>
+                                <Button
+                                    className={clsx(c.button1, {
+                                        [c.downloadingButton]: isDownloading,
+                                    })}
+                                    variant="contained"
+                                    aria-label="browser zip download button"
+                                    disabled={selectionCount === 0}
+                                    onClick={() => {
+                                        if (selectorRef && selectorRef.current) {
+                                            const sel = selectorRef.current.getSelected() || []
+                                            if (sel.length === 0) {
+                                                dispatch(
+                                                    setSnackBarText(
+                                                        'Please select products to download',
+                                                        'warning'
+                                                    )
+                                                )
+                                            } else {
+                                                setIsDownloading(true)
+                                                setDownloadId(downloadId + 1)
+                                                setError(null)
+                                                dispatch(
+                                                    ZipStreamCart(
+                                                        setStatus,
+                                                        setIsDownloading,
+                                                        setZipController,
+                                                        sel,
+                                                        (err) => {
+                                                            setError(err)
+                                                            setIsDownloading(false)
+                                                        }
+                                                    )
+                                                )
+                                            }
+                                        }
+                                    }}
+                                >
+                                    {isDownloading ? 'Download in Progress' : 'Download ZIP'}
+                                </Button>
+                            </span>
+                        </Tooltip>
                     </Box>
                     <div className={c.downloading}>
                         <div className={clsx(c.error, { [c.errorOn]: error != null })}>{error}</div>

--- a/src/pages/Cart/Content/Panel/Tabs/CSV/CSV.js
+++ b/src/pages/Cart/Content/Panel/Tabs/CSV/CSV.js
@@ -5,6 +5,7 @@ import { makeStyles, withStyles } from '@material-ui/core/styles'
 
 import Typography from '@material-ui/core/Typography'
 import Button from '@material-ui/core/Button'
+import Tooltip from '@material-ui/core/Tooltip'
 import clsx from 'clsx'
 
 import ProductDownloadSelector from '../../../../../../components/ProductDownloadSelector/ProductDownloadSelector'
@@ -78,6 +79,7 @@ function CSVTab(props) {
     const [downloadId, setDownloadId] = useState(0)
     const [status, setStatus] = useState(null)
     const [error, setError] = useState(null)
+    const [selectionCount, setSelectionCount] = useState(0)
 
     const [datestamp, setDatestamp] = useState()
 
@@ -104,43 +106,59 @@ function CSVTab(props) {
                         <Typography className={c.p}>
                             Select the products to include in your download:
                         </Typography>
-                        <ProductDownloadSelector ref={selectorRef} />
-                        <Button
-                            className={clsx(c.button1, {
-                                [c.downloadingButton]: isDownloading,
-                            })}
-                            variant="contained"
-                            aria-label="csv download button"
-                            onClick={() => {
-                                if (selectorRef && selectorRef.current) {
-                                    const sel = selectorRef.current.getSelected() || {}
-                                    if (sel.length == 0) {
-                                        dispatch(setSnackBarText('Nothing to download', 'warning'))
-                                    } else {
-                                        setIsDownloading(true)
-                                        setDownloadId(downloadId + 1)
-                                        setError(null)
-                                        const datestamp = new Date()
-                                            .toISOString()
-                                            .replace(/:/g, '_')
-                                            .replace(/\./g, '_')
-                                            .replace(/Z/g, '')
-                                        dispatch(
-                                            CSVCart(
-                                                setStatus,
-                                                setIsDownloading,
-                                                setOnStop,
-                                                sel,
-                                                datestamp
-                                            )
-                                        )
-                                        setDatestamp(datestamp)
-                                    }
-                                }
-                            }}
+                        <ProductDownloadSelector
+                            ref={selectorRef}
+                            onSelection={setSelectionCount}
+                        />
+                        <Tooltip
+                            title={selectionCount === 0 ? 'Select products above to download.' : ''}
+                            arrow
                         >
-                            {isDownloading ? 'Download in Progress' : 'Download CSV'}
-                        </Button>
+                            <span>
+                                <Button
+                                    className={clsx(c.button1, {
+                                        [c.downloadingButton]: isDownloading,
+                                    })}
+                                    variant="contained"
+                                    aria-label="csv download button"
+                                    disabled={selectionCount === 0}
+                                    onClick={() => {
+                                        if (selectorRef && selectorRef.current) {
+                                            const sel = selectorRef.current.getSelected() || {}
+                                            if (sel.length == 0) {
+                                                dispatch(
+                                                    setSnackBarText(
+                                                        'Please select products to download',
+                                                        'warning'
+                                                    )
+                                                )
+                                            } else {
+                                                setIsDownloading(true)
+                                                setDownloadId(downloadId + 1)
+                                                setError(null)
+                                                const datestamp = new Date()
+                                                    .toISOString()
+                                                    .replace(/:/g, '_')
+                                                    .replace(/\./g, '_')
+                                                    .replace(/Z/g, '')
+                                                dispatch(
+                                                    CSVCart(
+                                                        setStatus,
+                                                        setIsDownloading,
+                                                        setOnStop,
+                                                        sel,
+                                                        datestamp
+                                                    )
+                                                )
+                                                setDatestamp(datestamp)
+                                            }
+                                        }
+                                    }}
+                                >
+                                    {isDownloading ? 'Download in Progress' : 'Download CSV'}
+                                </Button>
+                            </span>
+                        </Tooltip>
                         <Typography className={c.p}>
                             Downloads a .csv named `./pdsimg-atlas_{datestamp}.csv` with the
                             following header:

--- a/src/pages/Cart/Content/Panel/Tabs/CURL/CURL.js
+++ b/src/pages/Cart/Content/Panel/Tabs/CURL/CURL.js
@@ -5,6 +5,7 @@ import { makeStyles, withStyles } from '@material-ui/core/styles'
 
 import Typography from '@material-ui/core/Typography'
 import Button from '@material-ui/core/Button'
+import Tooltip from '@material-ui/core/Tooltip'
 import clsx from 'clsx'
 
 import ProductDownloadSelector from '../../../../../../components/ProductDownloadSelector/ProductDownloadSelector'
@@ -78,6 +79,7 @@ function CURLTab(props) {
     const [downloadId, setDownloadId] = useState(0)
     const [status, setStatus] = useState(null)
     const [error, setError] = useState(null)
+    const [selectionCount, setSelectionCount] = useState(0)
 
     const [datestamp, setDatestamp] = useState()
 
@@ -104,43 +106,61 @@ function CURLTab(props) {
                         <Typography className={c.p}>
                             Select the products to include in your download:
                         </Typography>
-                        <ProductDownloadSelector ref={selectorRef} />
-                        <Button
-                            className={clsx(c.button1, {
-                                [c.downloadingButton]: isDownloading,
-                            })}
-                            variant="contained"
-                            aria-label="curl download button"
-                            onClick={() => {
-                                if (selectorRef && selectorRef.current) {
-                                    const sel = selectorRef.current.getSelected() || {}
-                                    if (sel.length == 0) {
-                                        dispatch(setSnackBarText('Nothing to download', 'warning'))
-                                    } else {
-                                        setIsDownloading(true)
-                                        setDownloadId(downloadId + 1)
-                                        setError(null)
-                                        const datestamp = new Date()
-                                            .toISOString()
-                                            .replace(/:/g, '_')
-                                            .replace(/\./g, '_')
-                                            .replace(/Z/g, '')
-                                        dispatch(
-                                            CURLCart(
-                                                setStatus,
-                                                setIsDownloading,
-                                                setOnStop,
-                                                sel,
-                                                datestamp
-                                            )
-                                        )
-                                        setDatestamp(datestamp)
-                                    }
-                                }
-                            }}
+                        <ProductDownloadSelector
+                            ref={selectorRef}
+                            onSelection={setSelectionCount}
+                        />
+                        <Tooltip
+                            title={selectionCount === 0 ? 'Select products above to download.' : ''}
+                            arrow
                         >
-                            {isDownloading ? 'Download in Progress' : 'Download CURL Script'}
-                        </Button>
+                            <span>
+                                <Button
+                                    className={clsx(c.button1, {
+                                        [c.downloadingButton]: isDownloading,
+                                    })}
+                                    variant="contained"
+                                    aria-label="curl download button"
+                                    disabled={selectionCount === 0}
+                                    onClick={() => {
+                                        if (selectorRef && selectorRef.current) {
+                                            const sel = selectorRef.current.getSelected() || {}
+                                            if (sel.length == 0) {
+                                                dispatch(
+                                                    setSnackBarText(
+                                                        'Please select products to download',
+                                                        'warning'
+                                                    )
+                                                )
+                                            } else {
+                                                setIsDownloading(true)
+                                                setDownloadId(downloadId + 1)
+                                                setError(null)
+                                                const datestamp = new Date()
+                                                    .toISOString()
+                                                    .replace(/:/g, '_')
+                                                    .replace(/\./g, '_')
+                                                    .replace(/Z/g, '')
+                                                dispatch(
+                                                    CURLCart(
+                                                        setStatus,
+                                                        setIsDownloading,
+                                                        setOnStop,
+                                                        sel,
+                                                        datestamp
+                                                    )
+                                                )
+                                                setDatestamp(datestamp)
+                                            }
+                                        }
+                                    }}
+                                >
+                                    {isDownloading
+                                        ? 'Download in Progress'
+                                        : 'Download CURL Script'}
+                                </Button>
+                            </span>
+                        </Tooltip>
                         <Typography className={c.p2}>Requires: curl 7.73.0+</Typography>
                         <Typography className={c.p}>
                             To provide bulk downloading of PDS Imaging products, we have provided a

--- a/src/pages/Cart/Content/Panel/Tabs/TXT/TXT.js
+++ b/src/pages/Cart/Content/Panel/Tabs/TXT/TXT.js
@@ -5,6 +5,7 @@ import { makeStyles, withStyles } from '@material-ui/core/styles'
 
 import Typography from '@material-ui/core/Typography'
 import Button from '@material-ui/core/Button'
+import Tooltip from '@material-ui/core/Tooltip'
 import clsx from 'clsx'
 
 import ProductDownloadSelector from '../../../../../../components/ProductDownloadSelector/ProductDownloadSelector'
@@ -78,6 +79,7 @@ function TXTTab(props) {
     const [downloadId, setDownloadId] = useState(0)
     const [status, setStatus] = useState(null)
     const [error, setError] = useState(null)
+    const [selectionCount, setSelectionCount] = useState(0)
 
     const [datestamp, setDatestamp] = useState()
 
@@ -104,43 +106,59 @@ function TXTTab(props) {
                         <Typography className={c.p}>
                             Select the products to include in your download:
                         </Typography>
-                        <ProductDownloadSelector ref={selectorRef} />
-                        <Button
-                            className={clsx(c.button1, {
-                                [c.downloadingButton]: isDownloading,
-                            })}
-                            variant="contained"
-                            aria-label="txt download button"
-                            onClick={() => {
-                                if (selectorRef && selectorRef.current) {
-                                    const sel = selectorRef.current.getSelected() || {}
-                                    if (sel.length == 0) {
-                                        dispatch(setSnackBarText('Nothing to download', 'warning'))
-                                    } else {
-                                        setIsDownloading(true)
-                                        setDownloadId(downloadId + 1)
-                                        setError(null)
-                                        const datestamp = new Date()
-                                            .toISOString()
-                                            .replace(/:/g, '_')
-                                            .replace(/\./g, '_')
-                                            .replace(/Z/g, '')
-                                        dispatch(
-                                            TXTCart(
-                                                setStatus,
-                                                setIsDownloading,
-                                                setOnStop,
-                                                sel,
-                                                datestamp
-                                            )
-                                        )
-                                        setDatestamp(datestamp)
-                                    }
-                                }
-                            }}
+                        <ProductDownloadSelector
+                            ref={selectorRef}
+                            onSelection={setSelectionCount}
+                        />
+                        <Tooltip
+                            title={selectionCount === 0 ? 'Select products above to download.' : ''}
+                            arrow
                         >
-                            {isDownloading ? 'Download in Progress' : 'Download TXT'}
-                        </Button>
+                            <span>
+                                <Button
+                                    className={clsx(c.button1, {
+                                        [c.downloadingButton]: isDownloading,
+                                    })}
+                                    variant="contained"
+                                    aria-label="txt download button"
+                                    disabled={selectionCount === 0}
+                                    onClick={() => {
+                                        if (selectorRef && selectorRef.current) {
+                                            const sel = selectorRef.current.getSelected() || {}
+                                            if (sel.length == 0) {
+                                                dispatch(
+                                                    setSnackBarText(
+                                                        'Please select products to download',
+                                                        'warning'
+                                                    )
+                                                )
+                                            } else {
+                                                setIsDownloading(true)
+                                                setDownloadId(downloadId + 1)
+                                                setError(null)
+                                                const datestamp = new Date()
+                                                    .toISOString()
+                                                    .replace(/:/g, '_')
+                                                    .replace(/\./g, '_')
+                                                    .replace(/Z/g, '')
+                                                dispatch(
+                                                    TXTCart(
+                                                        setStatus,
+                                                        setIsDownloading,
+                                                        setOnStop,
+                                                        sel,
+                                                        datestamp
+                                                    )
+                                                )
+                                                setDatestamp(datestamp)
+                                            }
+                                        }
+                                    }}
+                                >
+                                    {isDownloading ? 'Download in Progress' : 'Download TXT'}
+                                </Button>
+                            </span>
+                        </Tooltip>
                         <Typography className={c.p}>
                             Downloads a .txt file named `./pdsimg-atlas_{datestamp}.txt` that simply
                             lists out all download urls.

--- a/src/pages/Cart/Content/Panel/Tabs/WGET/WGET.js
+++ b/src/pages/Cart/Content/Panel/Tabs/WGET/WGET.js
@@ -5,6 +5,7 @@ import { makeStyles, withStyles } from '@material-ui/core/styles'
 
 import Typography from '@material-ui/core/Typography'
 import Button from '@material-ui/core/Button'
+import Tooltip from '@material-ui/core/Tooltip'
 import clsx from 'clsx'
 
 import ProductDownloadSelector from '../../../../../../components/ProductDownloadSelector/ProductDownloadSelector'
@@ -78,6 +79,7 @@ function WGETTab(props) {
     const [downloadId, setDownloadId] = useState(0)
     const [status, setStatus] = useState(null)
     const [error, setError] = useState(null)
+    const [selectionCount, setSelectionCount] = useState(0)
 
     const [datestamp, setDatestamp] = useState()
 
@@ -104,43 +106,61 @@ function WGETTab(props) {
                         <Typography className={c.p}>
                             Select the products to include in your download:
                         </Typography>
-                        <ProductDownloadSelector ref={selectorRef} />
-                        <Button
-                            className={clsx(c.button1, {
-                                [c.downloadingButton]: isDownloading,
-                            })}
-                            variant="contained"
-                            aria-label="wget download button"
-                            onClick={() => {
-                                if (selectorRef && selectorRef.current) {
-                                    const sel = selectorRef.current.getSelected() || {}
-                                    if (sel.length == 0) {
-                                        dispatch(setSnackBarText('Nothing to download', 'warning'))
-                                    } else {
-                                        setIsDownloading(true)
-                                        setDownloadId(downloadId + 1)
-                                        setError(null)
-                                        const datestamp = new Date()
-                                            .toISOString()
-                                            .replace(/:/g, '_')
-                                            .replace(/\./g, '_')
-                                            .replace(/Z/g, '')
-                                        dispatch(
-                                            WGETCart(
-                                                setStatus,
-                                                setIsDownloading,
-                                                setOnStop,
-                                                sel,
-                                                datestamp
-                                            )
-                                        )
-                                        setDatestamp(datestamp)
-                                    }
-                                }
-                            }}
+                        <ProductDownloadSelector
+                            ref={selectorRef}
+                            onSelection={setSelectionCount}
+                        />
+                        <Tooltip
+                            title={selectionCount === 0 ? 'Select products above to download.' : ''}
+                            arrow
                         >
-                            {isDownloading ? 'Download in Progress' : 'Download WGET Script'}
-                        </Button>
+                            <span>
+                                <Button
+                                    className={clsx(c.button1, {
+                                        [c.downloadingButton]: isDownloading,
+                                    })}
+                                    variant="contained"
+                                    aria-label="wget download button"
+                                    disabled={selectionCount === 0}
+                                    onClick={() => {
+                                        if (selectorRef && selectorRef.current) {
+                                            const sel = selectorRef.current.getSelected() || {}
+                                            if (sel.length == 0) {
+                                                dispatch(
+                                                    setSnackBarText(
+                                                        'Please select products to download',
+                                                        'warning'
+                                                    )
+                                                )
+                                            } else {
+                                                setIsDownloading(true)
+                                                setDownloadId(downloadId + 1)
+                                                setError(null)
+                                                const datestamp = new Date()
+                                                    .toISOString()
+                                                    .replace(/:/g, '_')
+                                                    .replace(/\./g, '_')
+                                                    .replace(/Z/g, '')
+                                                dispatch(
+                                                    WGETCart(
+                                                        setStatus,
+                                                        setIsDownloading,
+                                                        setOnStop,
+                                                        sel,
+                                                        datestamp
+                                                    )
+                                                )
+                                                setDatestamp(datestamp)
+                                            }
+                                        }
+                                    }}
+                                >
+                                    {isDownloading
+                                        ? 'Download in Progress'
+                                        : 'Download WGET Script'}
+                                </Button>
+                            </span>
+                        </Tooltip>
                         <Typography className={c.p}>
                             To provide bulk downloading of PDS Imaging products, we have provided a
                             set of pre-configured WGET commands below that can be executed on your


### PR DESCRIPTION
Closes #63 

Disables the Cart's download buttons if no products are selected. This also makes the "Nothing to download" unreachable because the download button cannot be pressed.