### PR TITLE
#80 Increase bundle agg size to 10k

### DIFF
--- a/src/core/redux/actions/actions.js
+++ b/src/core/redux/actions/actions.js
@@ -1728,13 +1728,13 @@ export const queryFilexColumn = (columnId, isLast, cb) => {
                         aggs[i] = {
                             terms: {
                                 field: ES_PATHS.archive.volume_id.join('.'),
-                                size: 1000,
+                                size: 10000,
                             },
                         }
                         aggs[`${i}_a`] = {
                             terms: {
                                 field: ES_PATHS.archive.bundle_id.join('.'),
-                                size: 1000,
+                                size: 10000,
                             },
                         }
                         break


### PR DESCRIPTION
Closes #80 

Simply increases the agg size from 1k to 10k, which is well over the 6.5k volumes in MRO (which already seems like an overly high edge case). No performance hit was found when increasing this too.

