### PR TITLE
#77 Differentiate PDS3 from PDS4 in AE

### DIFF
--- a/src/pages/FileExplorer/Columns/Columns.js
+++ b/src/pages/FileExplorer/Columns/Columns.js
@@ -62,6 +62,8 @@ import Highlighter from 'react-highlight-words'
 
 const initialColumnWidth = 220
 const minColumnWidth = 220
+const volumeColumnWidth = 230
+const minVolumeColumnWidth = 230
 
 const useStyles = makeStyles((theme) => ({
     Columns: {
@@ -474,6 +476,30 @@ const useStyles = makeStyles((theme) => ({
     highlight: {
         fontWeight: 'bold',
     },
+    subHeader: {
+        'padding': '8px 12px 4px 12px',
+        'borderBottom': 'none',
+        'background': theme.palette.swatches.grey.grey50,
+        'margin': '0px',
+        'cursor': 'default',
+        '&:hover': {
+            background: theme.palette.swatches.grey.grey50,
+        },
+    },
+    subHeaderText: {
+        'color': theme.palette.swatches.grey.grey600,
+        'fontWeight': 600,
+        'textTransform': 'uppercase',
+        'letterSpacing': '0.5px',
+        'fontSize': '11px',
+    },
+    pdsVersionText: {
+        'fontSize': '0.7em',
+        'fontWeight': 400,
+        'color': theme.palette.swatches.grey.grey500,
+        'marginLeft': theme.spacing(0.5),
+        'opacity': 0.8,
+    },
 }))
 
 const Column = (props) => {
@@ -565,7 +591,8 @@ const Column = (props) => {
                     if (name == null) name = getIn(c, 'key', '')
                     if (name.length > longestName.length) longestName = name
                 })
-                const bestWidth = Math.max(longestName.length * 9 + 70, minColumnWidth)
+                const minWidth = params.type === 'volume' ? minVolumeColumnWidth : minColumnWidth
+                const bestWidth = Math.max(longestName.length * 9 + 70, minWidth)
                 colRef.current.style.width = `${bestWidth}px`
             }
         }
@@ -641,7 +668,7 @@ const Column = (props) => {
             )}
             style={
                 !(!showFilterColumns && params.type === 'filter')
-                    ? { width: initialColumnWidth }
+                    ? { width: params.type === 'volume' ? volumeColumnWidth : initialColumnWidth }
                     : {}
             }
             ref={colRef}
@@ -726,7 +753,32 @@ const Column = (props) => {
                                                 })}
                                                 variant="h6"
                                             >
-                                                {pds_standard === 'pds3' ? 'Volumes' : 'Bundles'}
+                                                {(() => {
+                                                    if (!content || content.length === 0) {
+                                                        return pds_standard === 'pds3' ? 'Volumes' : 'Bundles'
+                                                    }
+                                                    
+                                                    const hasBundles = content.some(item => item.type === 'bundle')
+                                                    const hasVolumes = content.some(item => item.type === 'volume' || !item.type)
+                                                    
+                                                    if (hasBundles && hasVolumes) {
+                                                        return 'Bundles / Volumes'
+                                                    } else if (hasBundles) {
+                                                        return (
+                                                            <>
+                                                                Bundles
+                                                                <span className={c.pdsVersionText}>(PDS4)</span>
+                                                            </>
+                                                        )
+                                                    } else {
+                                                        return (
+                                                            <>
+                                                                Volumes
+                                                                <span className={c.pdsVersionText}>(PDS3)</span>
+                                                            </>
+                                                        )
+                                                    }
+                                                })()}
                                             </Typography>
                                         </div>
                                         <div>
@@ -993,44 +1045,99 @@ const Column = (props) => {
                                       </li>
                                   ))
                                 : params.type === 'volume'
-                                ? content.map((result, idx) => (
-                                      <li
-                                          key={idx}
-                                          className={clsx(c.listItem, c.listItemFilter, {
-                                              [c.listItemActive]:
-                                                  params.active && params.active.key === result.key,
+                                ? (() => {
+                                      // Group content by type (bundle vs volume)
+                                      // Fallback: items without type are treated as volumes
+                                      const bundles = content.filter(item => item.type === 'bundle')
+                                      const volumes = content.filter(item => item.type === 'volume' || !item.type)
+                                      
+                                      const renderItems = (items, typePrefix) => items.map((result, idx) => {
+                                                                                     const uniqueKey = `${result.type || 'volume'}-${result.key}`
+                                          return (
+                                              <li
+                                                  key={`${typePrefix}-${idx}`}
+                                                  className={clsx(c.listItem, c.listItemFilter, {
+                                                      [c.listItemActive]:
+                                                          params.active && (
+                                                              params.active.uniqueKey === uniqueKey ||
+                                                              (!params.active.uniqueKey && params.active.key === result.key)
+                                                          ),
 
-                                              [c.listItemMobile]: isMobile,
-                                          })}
-                                          onClick={() => {
-                                              if (!isMobile) setShowFilterColumns(false)
-                                              dispatch(
-                                                  updateFilexColumn(columnId, {
-                                                      active: { ...result, fs_type: 'volume' },
-                                                  })
-                                              )
-                                          }}
-                                      >
-                                          <div className={c.liflex}>
-                                              <div className={c.liType}>
-                                                  <svg className={c.iconSvg} viewBox="0 0 24 24">
-                                                      <path
-                                                          fill="currentColor"
-                                                          d="M2,10.96C1.5,10.68 1.35,10.07 1.63,9.59L3.13,7C3.24,6.8 3.41,6.66 3.6,6.58L11.43,2.18C11.59,2.06 11.79,2 12,2C12.21,2 12.41,2.06 12.57,2.18L20.47,6.62C20.66,6.72 20.82,6.88 20.91,7.08L22.36,9.6C22.64,10.08 22.47,10.69 22,10.96L21,11.54V16.5C21,16.88 20.79,17.21 20.47,17.38L12.57,21.82C12.41,21.94 12.21,22 12,22C11.79,22 11.59,21.94 11.43,21.82L3.53,17.38C3.21,17.21 3,16.88 3,16.5V10.96C2.7,11.13 2.32,11.14 2,10.96M12,4.15V4.15L12,10.85V10.85L17.96,7.5L12,4.15M5,15.91L11,19.29V12.58L5,9.21V15.91M19,15.91V12.69L14,15.59C13.67,15.77 13.3,15.76 13,15.6V19.29L19,15.91M13.85,13.36L20.13,9.73L19.55,8.72L13.27,12.35L13.85,13.36Z"
-                                                      />
-                                                  </svg>
-                                              </div>
-                                              <div
-                                                  className={clsx(c.liName, {
-                                                      [c.liNameMobile]: isMobile,
+                                                      [c.listItemMobile]: isMobile,
                                                   })}
-                                                  title={result.key}
+                                                  onClick={() => {
+                                                      if (!isMobile) setShowFilterColumns(false)
+                                                      dispatch(
+                                                          updateFilexColumn(columnId, {
+                                                              active: { 
+                                                                  ...result, 
+                                                                  fs_type: 'volume',
+                                                                  uniqueKey: uniqueKey,
+                                                                  key: result.key // Keep original key for compatibility
+                                                              },
+                                                          })
+                                                      )
+                                                  }}
                                               >
-                                                  {getFilename(result.key)}
-                                              </div>
-                                          </div>
-                                      </li>
-                                  ))
+                                                  <div className={c.liflex}>
+                                                      <div className={c.liType}>
+                                                          <svg className={c.iconSvg} viewBox="0 0 24 24">
+                                                              <path
+                                                                  fill="currentColor"
+                                                                  d="M2,10.96C1.5,10.68 1.35,10.07 1.63,9.59L3.13,7C3.24,6.8 3.41,6.66 3.6,6.58L11.43,2.18C11.59,2.06 11.79,2 12,2C12.21,2 12.41,2.06 12.57,2.18L20.47,6.62C20.66,6.72 20.82,6.88 20.91,7.08L22.36,9.6C22.64,10.08 22.47,10.69 22,10.96L21,11.54V16.5C21,16.88 20.79,17.21 20.47,17.38L12.57,21.82C12.41,21.94 12.21,22 12,22C11.79,22 11.59,21.94 11.43,21.82L3.53,17.38C3.21,17.21 3,16.88 3,16.5V10.96C2.7,11.13 2.32,11.14 2,10.96M12,4.15V4.15L12,10.85V10.85L17.96,7.5L12,4.15M5,15.91L11,19.29V12.58L5,9.21V15.91M19,15.91V12.69L14,15.59C13.67,15.77 13.3,15.76 13,15.6V19.29L19,15.91M13.85,13.36L20.13,9.73L19.55,8.72L13.27,12.35L13.85,13.36Z"
+                                                              />
+                                                          </svg>
+                                                      </div>
+                                                      <div
+                                                          className={clsx(c.liName, {
+                                                              [c.liNameMobile]: isMobile,
+                                                          })}
+                                                          title={result.key}
+                                                      >
+                                                          {getFilename(result.key)}
+                                                      </div>
+                                                  </div>
+                                              </li>
+                                          )
+                                      })
+
+                                      return (
+                                          <>
+                                              {(() => {
+                                                  const hasBoth = bundles.length > 0 && volumes.length > 0
+                                                  
+                                                  return (
+                                                      <>
+                                                          {bundles.length > 0 && (
+                                                              <>
+                                                                  {hasBoth && (
+                                                                      <li key="bundles-header" className={c.subHeader}>
+                                                                          <Typography variant="caption" className={c.subHeaderText}>
+                                                                              Bundles (PDS4)
+                                                                          </Typography>
+                                                                      </li>
+                                                                  )}
+                                                                  {renderItems(bundles, 'bundle')}
+                                                              </>
+                                                          )}
+                                                          {volumes.length > 0 && (
+                                                              <>
+                                                                  {hasBoth && (
+                                                                      <li key="volumes-header" className={c.subHeader}>
+                                                                          <Typography variant="caption" className={c.subHeaderText}>
+                                                                              Volumes (PDS3)
+                                                                          </Typography>
+                                                                      </li>
+                                                                  )}
+                                                                  {renderItems(volumes, 'volume')}
+                                                              </>
+                                                          )}
+                                                      </>
+                                                  )
+                                              })()}
+                                          </>
+                                      )
+                                  })()
                                 : content.map((r, idx) => {
                                       const s = r._source || {}
                                       const result = s.archive || {}

--- a/src/pages/FileExplorer/Heading/Heading.js
+++ b/src/pages/FileExplorer/Heading/Heading.js
@@ -100,7 +100,12 @@ const Heading = (props) => {
             v = v[v.length - 1]
             if (c.active) getParams.push({ key: v, value: c.active.key })
         } else if (c.type === 'volume') {
-            if (c.active) getParams.push({ key: 'bundle', value: c.active.key })
+            if (c.active) {
+                getParams.push({ key: 'bundle', value: c.active.key })
+                // Add pds_standard parameter to distinguish bundles from volumes
+                const pdsStandard = (c.active.type === 'volume') ? '3' : '4'
+                getParams.push({ key: 'pds', value: pdsStandard })
+            }
         }
     })
 


### PR DESCRIPTION
Closes #77 

With _Claude 4 Sonnet Thinking_

# Fix Bundle/Volume Conflicts in File Explorer

## Summary
Resolves UI conflicts when bundles and volumes share the same name in the file explorer. Previously, clicking on a bundle or volume with the same name would cause both to be selected, and navigating into them would incorrectly merge files from both PDS3 and PDS4 sources.

## Key Changes

### 🔍 **Backend Query Improvements**
- **Enhanced Elasticsearch aggregations** to include `type: "bundle"` and `type: "volume"` properties
- **Added PDS standard filtering** (`archive.pds_standard: pds3/pds4`) to ensure bundle/volume navigation only shows correct files
- **Improved query specificity** to prevent cross-contamination of PDS3 and PDS4 data

### 🎯 **Unique Identification System**
- **Replaced simple name-based selection** with `uniqueKey` system (`bundle-MSGRMDS_1001` vs `volume-MSGRMDS_1001`)
- **Maintains backward compatibility** for existing active selections
- **Prevents UI conflicts** when bundles and volumes have identical names

### 🔗 **Enhanced Deep Linking**
- **Added `pds` URL parameter** (`?mission=mess&bundle=MSGRMDS_1001&pds=4`)
- **Automatic URL generation** includes PDS standard for proper state restoration
- **Preserves navigation context** between bundles (PDS4) and volumes (PDS3)

### 🎨 **Improved User Experience**
- **Dynamic column titles**: 
  - Mixed content: "Bundles / Volumes"
  - Single type: "Bundles (PDS4)" or "Volumes (PDS3)"
- **Conditional subheadings**: Only show "Bundles (PDS4)" / "Volumes (PDS3)" sections when both types are present
- **Subtle PDS version styling**: Smaller, lighter text for technical details
- **Optimized column width**: Volume columns now 230px to accommodate longer titles

## Technical Details

### Files Modified
- `src/core/redux/actions/actions.js` - Query filtering and URL parameter handling
- `src/pages/FileExplorer/Columns/Columns.js` - UI rendering and selection logic  
- `src/pages/FileExplorer/Heading/Heading.js` - URL generation for deep linking

### Backward Compatibility
- ✅ Existing URLs without `pds` parameter default to PDS3 (volumes)
- ✅ Old selection logic falls back gracefully for items without `uniqueKey`
- ✅ No breaking changes to existing API or data structures

## Example URLs
**Before**: `?mission=mess&bundle=MSGRMDS_1001` (ambiguous)
**After**: 
- Bundle: `?mission=mess&bundle=MSGRMDS_1001&pds=4`
- Volume: `?mission=mess&bundle=MSGRMDS_1001&pds=3`

## User Impact
- 🚫 **Eliminates confusion** when bundles and volumes share names
- 🎯 **Accurate navigation** - users see only the correct files for their selection
- 🔗 **Reliable deep linking** - URLs properly restore exact bundle/volume state
- 📱 **Cleaner interface** - organized presentation with contextual headings

## Images
### Mixed Bundles/Volumes Column:
<img width="892" height="737" alt="230975345" src="https://github.com/user-attachments/assets/27e05f0c-f96c-4851-babb-49216585d93e" />

### Unmixed Bundles/Volumes Column:
<img width="1140" height="705" alt="9283723626" src="https://github.com/user-attachments/assets/aba27e3f-c1d9-478a-afa0-f99b654ffa8c" />
