### PR TITLE
#81 Search within facets

### DIFF
--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -67,7 +67,8 @@ const AccordionSummary = withStyles((theme) => ({
         'zIndex': 2,
         'borderLeft': '2px solid rgba(0,0,0,0)',
         'borderRight': `1px solid ${theme.palette.swatches.grey.grey200}`,
-        'transition': 'background 0.2s ease-out, border 0.2s ease-out',
+        'transition': 'unset',
+        'alignItems': 'flex-start',
         '&:hover': {
             background: theme.palette.swatches.grey.grey150,
         },
@@ -78,8 +79,9 @@ const AccordionSummary = withStyles((theme) => ({
         },
     },
     content: {
+        'margin': '4px 0',
         '&$expanded': {
-            margin: '12px 0',
+            margin: '4px 0',
         },
     },
     expandIcon: {
@@ -173,6 +175,9 @@ const useStyles = makeStyles((theme) => ({
     filterDownWrapper: {
         display: 'flex',
         justifyContent: 'space-between',
+        position: 'relative',
+        left: '-41px',
+        width: 'calc(100% + 41px)',
     },
     filterDown: {
         'flex': 1,
@@ -415,7 +420,7 @@ const Filter = (props) => {
                             )}
                             */}
                             {expanded && isListFilter && (
-                                <Tooltip title="Filter Down" arrow>
+                                <Tooltip title="Filter Further" arrow>
                                     <IconButton
                                         className={clsx(c.settingsButton, {
                                             [c.settingsButtonActive]: isFilterDownOpen,

--- a/src/components/Filter/subcomponents/ListFilter/ListFilter.js
+++ b/src/components/Filter/subcomponents/ListFilter/ListFilter.js
@@ -56,6 +56,12 @@ const useStyles = makeStyles((theme) => ({
         color: theme.palette.swatches.grey.grey600,
         textAlign: 'center',
     },
+    moreResults: {
+        textAlign: 'center',
+        background: theme.palette.swatches.red.red500,
+        color: theme.palette.swatches.grey.grey100,
+        padding: '4px 0px',
+    },
 }))
 
 const ListFilter = (props) => {
@@ -106,6 +112,9 @@ const ListFilter = (props) => {
                     ))
                 ) : (
                     <div className={c.noData}>No aggregation data</div>
+                )}
+                {facet?.fields?.length >= 500 && (
+                    <li className={c.moreResults}>Only showing the first 500 results.</li>
                 )}
             </ul>
         </div>

--- a/src/core/redux/actions/actions.js
+++ b/src/core/redux/actions/actions.js
@@ -623,7 +623,24 @@ export const search = (page, filtersNeedUpdate, pageNeedsUpdate, url, forceActiv
                                 break
                             default:
                                 Object.keys(facet.state).forEach((value) => {
-                                    if (facet.state[value]) {
+                                    if (
+                                        value === '__filter' &&
+                                        facet.state[value] != null &&
+                                        facet.state[value] != ''
+                                    ) {
+                                        query.bool = query.bool || {
+                                            must: [],
+                                        }
+                                        let qs_input = '.*' + facet.state[value] + '.*'
+                                        toAddToMust.push({
+                                            regexp: {
+                                                [field]: {
+                                                    value: qs_input,
+                                                    case_insensitive: true,
+                                                },
+                                            },
+                                        })
+                                    } else if (facet.state[value]) {
                                         query.bool = query.bool || {
                                             must: [],
                                         }
@@ -822,6 +839,13 @@ export const search = (page, filtersNeedUpdate, pageNeedsUpdate, url, forceActiv
                             nextActiveFilters[filter].facets.forEach((facet, i) => {
                                 if (facet.type == 'keyword') {
                                     let buckets = aggs[filter].buckets
+
+                                    // Since we'ew filtering, clear the existing bucket aggs
+                                    if (
+                                        facet?.state?.__filter != null &&
+                                        facet?.state?.__filter != ''
+                                    )
+                                        nextActiveFilters[filter].facets[i].fields = []
 
                                     // Account for nested buckets
                                     if (aggs[filter].nested) {

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -155,6 +155,8 @@ export const mergeFields = (currentFields, returnedFields) => {
         }
     })
 
+    newFields.sort((a, b) => a.key.localeCompare(b.key))
+
     return newFields
 }
 

--- a/src/facets/FacetBuilder.js
+++ b/src/facets/FacetBuilder.js
@@ -187,7 +187,7 @@ export const getInitialActiveFilters = (mapping) => {
                 "A textual search over product names. Regular expressions are supported using ElasticSearch's regexp syntax.",
             facets: [
                 {
-                    field_name: 'Search Product Names',
+                    field_name: 'Search Product Names (regex supported)',
                     field: '*',
                     component: 'text',
                     type: 'query_string',

--- a/src/pages/Search/Panels/ResultsPanel/subcomponents/ChippedFilters/ChippedFilters.js
+++ b/src/pages/Search/Panels/ResultsPanel/subcomponents/ChippedFilters/ChippedFilters.js
@@ -45,6 +45,7 @@ const ChippedFilters = (props) => {
                     if (facet.state) {
                         Object.keys(facet.state).forEach((key) => {
                             let value = facet.state[key]
+                            if (key === '__filter' && (value == '' || value == null)) return
                             if (value === false) return
                             if (value === true) value = key
 
@@ -66,7 +67,7 @@ const ChippedFilters = (props) => {
                                     className={c.chip}
                                     label={`${capitalize(
                                         activeFilters[filterKey].display_name || filterKey
-                                    )}${subName}: ${value}`}
+                                    )}${subName}: ${key === '__filter' ? `*${value}*` : value}`}
                                     key={chips.length}
                                     onDelete={() => {
                                         dispatch(


### PR DESCRIPTION
Closes #81

### Adds
- An expandable text box search per facet.
- This text box search both filters the facet's list of item as well as can be used to narrow the final search results.
- Supports lucene regex syntax as well.
- Also added a quick "Clear All Selections" button to each facet's header to quickly deselect everything within it. 

<img width="367" height="375" alt="9328764365" src="https://github.com/user-attachments/assets/db9804be-7c47-41c8-a5bf-22af646e168a" />
