### PR TITLE
#117 Atlas always sort by uri after main sort so that sort order is c…

### DIFF
--- a/src/core/redux/actions/actions.js
+++ b/src/core/redux/actions/actions.js
@@ -730,7 +730,7 @@ export const search = (page, filtersNeedUpdate, pageNeedsUpdate, url, forceActiv
             sort: [
                 {
                     [resultSorting.field]: resultSorting.direction,
-                    [ES_PATHS.uri.join('.')]: 'desc',
+                    [ES_PATHS.uri.join('.')]: 'asc',
                     [ES_PATHS.release_id.join('.')]: 'desc',
                 },
             ],


### PR DESCRIPTION
…onsistent

Closes #117

Besides auto-formatting changes, the only change was adding:
```
L733 [ES_PATHS.uri.join('.')]: 'asc', 
```

This solves the issue where products with the same exact timestamp may become randomly arranged in the search results.