### PR TITLE
Updated base image for docker image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Builder
 ############################
 
-FROM artifactory.jpl.nasa.gov:17001/node:lts-jod as builder
+FROM node:lts-jod AS builder
 
 # Add git
 RUN apt-get update \
@@ -47,7 +47,7 @@ WORKDIR /usr/src/app/
 # Runner
 ############################
 
-FROM artifactory.jpl.nasa.gov:17001/node:lts-jod as runner
+FROM node:lts-jod AS runner
 
 # Create app directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary

Updated base docker image to use a publicly available base image because our repo is hosted on public GH and we won't have access to our enterprise instance of Artifactory when we add a GH workflow to build our docker image.

## ⚙️ Test Data and/or Report

Was able to successfully build and run image locally. Future PR will address building the image using CICD with configuration management.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Resolves #170 

