### PR TITLE
Updated `branch-cicd` GitHub workflow that tests our build status using the Node.js version specified in `.nvmrc`

### DIFF
--- a/.github/workflows/branch-cicd.yml
+++ b/.github/workflows/branch-cicd.yml
@@ -14,11 +14,19 @@ jobs:
     runs-on: ubuntu-latest
     name: Atlas Test Build
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Read .nvmrc and set environment variable
+        id: read_nvmrc
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_ENV
+      - name: "Set up Node.js (${{ env.NODE_VERSION }})"
+        uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
-      - run: npm ci
-      #- run: CI=true npm test --if-present
-      - run: npm run build --if-present
+      - name: Install dependencies
+        run: npm ci
+      #- name: Run tests
+      #  run: CI=true npm test --if-present
+      - name: Build the application
+        run: npm run build --if-present


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary

Updated the GitHub workflow defined in branch-cicd to resolve issus when it was run. The workflow was updated to 1) use the version of Node.js specified in our .nvmrc and 2) no longer use the matrix strategy approach since we need to ensure our application builds successfully agains the version specified in .nvmrc.

## ⚙️ Test Data and/or Report
One of the following should be included here:
* Reference to regression test included in code (preferred wherever reasonable)
* Attach test data here + outputs of tests

Tested workflow locally using `act`. Will inspect workflow execution when PR is opened as it will be triggered then.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Fixes #95 

