### PR TITLE
Fixed display of file path in Archive Explorer so that the PDS standard is not appended to the end of the file path

### DIFF
--- a/src/pages/FileExplorer/Heading/Heading.js
+++ b/src/pages/FileExplorer/Heading/Heading.js
@@ -119,7 +119,7 @@ const Heading = (props) => {
         url += `${idx === 0 ? '?' : '&'}${p.key}=${encodeURI(p.value)}`
 
         const skipKeys = ['pds'];
-        if (skipKeys.includes(p.key)) {
+        if (skipKeys.includes(p.key.toLowerCase())) {
             return;
         }
 


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary

Updated rendered file path displayed in archive explorer as the user navigates the archive so that the PDS standard version number isn't appended to the end of the file path.


## ⚙️ Test Data and/or Report

Tested locally and ensured that the PDS query param remains in the URL, but is not appended to the file path displayed in the UI:

<img width="1882" height="680" alt="image" src="https://github.com/user-attachments/assets/7741bff3-ac78-4b01-bcad-2420aa6c1e04" />


## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

Fixes #202 
