### PR TITLE
#209 Archive-Explorer - Support for deprecated folder

### DIFF
--- a/src/core/redux/actions/actions.js
+++ b/src/core/redux/actions/actions.js
@@ -75,6 +75,7 @@ let flatActions = [
     'SET_LAST_FILEX_FILTER_DOC',
     'SET_FILEX_PREVIEW',
     'SET_LAST_REGEX_QUERY',
+    'SET_SHOW_DEPRECATED',
 
     // ================= CART RELATED =================
     'ADD_TO_CART',
@@ -710,6 +711,20 @@ export const search = (page, filtersNeedUpdate, pageNeedsUpdate, url, forceActiv
             query.bool.must = query.bool.must || []
             query.bool.must.push({ exists: { field: 'gather.uri' } })
         }
+
+        // Always filter out deprecated products in search
+        query.bool = query.bool || {}
+        query.bool.must_not = query.bool.must_not || []
+        query.bool.must_not.push({
+            wildcard: {
+                'gather.pds_archive.bundle_id': '*deprecated*',
+            },
+        })
+        query.bool.must_not.push({
+            wildcard: {
+                'gather.pds_archive.volume_id': '*deprecated*',
+            },
+        })
 
         // === Secondary aggs
         // Always include a mission agg so that other components can know
@@ -1814,6 +1829,22 @@ export const queryFilexColumn = (columnId, isLast, cb) => {
                 },
             })
 
+        // Filter out deprecated items at ES query level
+        const showDeprecated = state.getIn(['showDeprecated'], false)
+        if (column.type === 'volume' && !showDeprecated) {
+            query.bool.must_not = query.bool.must_not || []
+            query.bool.must_not.push({
+                wildcard: {
+                    [ES_PATHS.archive.volume_id.join('.')]: '*deprecated*',
+                },
+            })
+            query.bool.must_not.push({
+                wildcard: {
+                    [ES_PATHS.archive.bundle_id.join('.')]: '*deprecated*',
+                },
+            })
+        }
+
         // Make aggs
 
         const aggs = {}
@@ -2159,6 +2190,13 @@ export const setFilexPreview = (previewItem) => {
         payload: {
             previewItem,
         },
+    }
+}
+
+export const setShowDeprecated = (showDeprecated) => {
+    return {
+        type: ACTIONS.SET_SHOW_DEPRECATED,
+        payload: { showDeprecated },
     }
 }
 

--- a/src/core/redux/reducers/reducers.js
+++ b/src/core/redux/reducers/reducers.js
@@ -49,6 +49,7 @@ const reducerFuncs = {
     SET_FILEX_PREVIEW: setFilexPreview,
     SET_LAST_FILEX_FILTER_DOC: setLastFilexFilterDoc,
     SET_LAST_REGEX_QUERY: setLastRegexQuery,
+    SET_SHOW_DEPRECATED: setShowDeprecated,
 
     // ================= CART RELATED =================
     ADD_TO_CART: addToCart,
@@ -461,6 +462,10 @@ function setLastQuery(state, payload) {
  */
 function setLastRegexQuery(state, payload) {
     return state.setIn(['lastRegexQuery'], fromJS({ total: payload.total, query: payload.query }))
+}
+
+function setShowDeprecated(state, payload) {
+    return state.setIn(['showDeprecated'], payload.showDeprecated)
 }
 
 /**

--- a/src/core/redux/store/initial.js
+++ b/src/core/redux/store/initial.js
@@ -136,6 +136,7 @@ export const INITIAL = (() => {
         filexPreview: {},
         lastFilexFilterDoc: null,
         lastRegexQuery: null,
+        showDeprecated: false,
 
         // ================= CART RELATED =================
         cart: storageCart,

--- a/src/pages/FileExplorer/Columns/Columns.js
+++ b/src/pages/FileExplorer/Columns/Columns.js
@@ -26,6 +26,7 @@ import {
     setModal,
     addToCart,
     setSnackBarText,
+    setShowDeprecated,
 } from '../../../core/redux/actions/actions'
 
 import { makeStyles } from '@mui/styles'
@@ -47,6 +48,7 @@ import MoreVertIcon from '@mui/icons-material/MoreVert'
 import SortIcon from '@mui/icons-material/Sort'
 import InsertDriveFileOutlinedIcon from '@mui/icons-material/InsertDriveFileOutlined'
 import FolderIcon from '@mui/icons-material/Folder'
+import FolderOffIcon from '@mui/icons-material/FolderOff'
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
@@ -64,6 +66,7 @@ const initialColumnWidth = 220
 const minColumnWidth = 220
 const volumeColumnWidth = 230
 const minVolumeColumnWidth = 230
+const DEPRECATED_COLOR = '#834325'
 
 const useStyles = makeStyles((theme) => ({
     Columns: {
@@ -258,6 +261,13 @@ const useStyles = makeStyles((theme) => ({
     },
     liNameMobile: {
         lineHeight: `${theme.headHeights[3]}px`,
+    },
+    liTypeDeprecated: {
+        width: '22px',
+        padding: '2px 2px 2px 5px',
+    },
+    deprecatedColor: {
+        color: DEPRECATED_COLOR,
     },
     listItemActive: {
         background: `${theme.palette.accent.main} !important`,
@@ -527,6 +537,10 @@ const Column = (props) => {
 
     const dispatch = useDispatch()
 
+    const showDeprecated = useSelector((state) => {
+        return state.getIn(['showDeprecated'], false)
+    })
+
     const colRef = useRef(null)
     const firstItemRef = useRef(null)
 
@@ -693,7 +707,8 @@ const Column = (props) => {
                                     onClick={() => {
                                         mobileBack()
                                     }}
-                                    size="large">
+                                    size="large"
+                                >
                                     <ArrowBackIcon fontSize="small" />
                                 </IconButton>
                             )}
@@ -724,14 +739,14 @@ const Column = (props) => {
                                         ))}
                                     </Select>
                                     */
-                                    (<Typography
+                                    <Typography
                                         className={clsx(c.volumeTitle, {
                                             [c.volumeTitleMobile]: isMobile,
                                         })}
                                         variant="h6"
                                     >
                                         {params.display_name}
-                                    </Typography>)
+                                    </Typography>
                                 ) : null}
                                 {params.type === 'volume' ? (
                                     <div className={c.flex2}>
@@ -743,7 +758,8 @@ const Column = (props) => {
                                                     onClick={() => {
                                                         setShowFilterColumns(true)
                                                     }}
-                                                    size="large">
+                                                    size="large"
+                                                >
                                                     <ArrowBackIcon fontSize="small" />
                                                 </IconButton>
                                             )}
@@ -792,7 +808,30 @@ const Column = (props) => {
                                                 })()}
                                             </Typography>
                                         </div>
-                                        <div>
+                                        <div className={c.flex}>
+                                            <MenuButton
+                                                key={1}
+                                                options={['Show Deprecated']}
+                                                checkboxIndices={[0]}
+                                                active={showDeprecated ? 'Show Deprecated' : null}
+                                                buttonComponent={
+                                                    <MoreVertIcon fontSize="inherit" />
+                                                }
+                                                title={'Options'}
+                                                onChange={(option, idx) => {
+                                                    if (option === 'Show Deprecated') {
+                                                        // Toggle show deprecated
+                                                        dispatch(setShowDeprecated(!showDeprecated))
+                                                        // Clear results and re-query to apply filter
+                                                        dispatch(
+                                                            updateFilexColumn(columnId, {
+                                                                results: null,
+                                                            })
+                                                        )
+                                                        dispatch(queryFilexColumn(columnId, null, null))
+                                                    }
+                                                }}
+                                            />
                                             <Tooltip title="URI Regex Search Here" arrow>
                                                 <IconButton
                                                     //className={}
@@ -804,29 +843,11 @@ const Column = (props) => {
                                                             })
                                                         )
                                                     }}
-                                                    size="large">
+                                                    size="large"
+                                                >
                                                     <SearchIcon fontSize="small" />
                                                 </IconButton>
                                             </Tooltip>
-                                            {/*
-                                            <MenuButton
-                                                key={1}
-                                                options={['Filter', 'Regex Search']}
-                                                buttonComponent={
-                                                    <MoreVertIcon fontSize="inherit" />
-                                                }
-                                                title={'Actions'}
-                                                onChange={(option) => {
-                                                    if (option === 'Filter')
-                                                        setFilterSearchOpen(!filterSearchOpen)
-                                                    else if (option === 'Regex Search')
-                                                        dispatch(
-                                                            setModal('regex', {
-                                                                uri: currentParentUri,
-                                                            })
-                                                        )
-                                                }}
-                                            />*/}
                                         </div>
                                     </div>
                                 ) : null}
@@ -850,7 +871,8 @@ const Column = (props) => {
                                                     onClick={() => {
                                                         setFilterSearchOpen(!filterSearchOpen)
                                                     }}
-                                                    size="large">
+                                                    size="large"
+                                                >
                                                     <FilterListIcon fontSize="small" />
                                                 </IconButton>
                                             </Tooltip>
@@ -866,7 +888,8 @@ const Column = (props) => {
                                                             })
                                                         )
                                                     }}
-                                                    size="large">
+                                                    size="large"
+                                                >
                                                     <SearchIcon fontSize="small" />
                                                 </IconButton>
                                             </Tooltip>
@@ -900,7 +923,8 @@ const Column = (props) => {
                                     onClick={() => {
                                         setShowMobilePreview(true, prevColumn.active)
                                     }}
-                                    size="large">
+                                    size="large"
+                                >
                                     <InfoOutlinedIcon fontSize="small" />
                                 </IconButton>
                             )}
@@ -1082,6 +1106,14 @@ const Column = (props) => {
                                               const uniqueKey = `${result.type || 'volume'}-${
                                                   result.key
                                               }`
+                                              const isDeprecated = result.key
+                                                  .toLowerCase()
+                                                  .includes('deprecated')
+                                              const isActive =
+                                                  params.active &&
+                                                  (params.active.uniqueKey === uniqueKey ||
+                                                      (!params.active.uniqueKey &&
+                                                          params.active.key === result.key))
                                               return (
                                                   <li
                                                       key={`${typePrefix}-${idx}`}
@@ -1089,14 +1121,7 @@ const Column = (props) => {
                                                           c.listItem,
                                                           c.listItemFilter,
                                                           {
-                                                              [c.listItemActive]:
-                                                                  params.active &&
-                                                                  (params.active.uniqueKey ===
-                                                                      uniqueKey ||
-                                                                      (!params.active.uniqueKey &&
-                                                                          params.active.key ===
-                                                                              result.key)),
-
+                                                              [c.listItemActive]: isActive,
                                                               [c.listItemMobile]: isMobile,
                                                           }
                                                       )}
@@ -1115,20 +1140,33 @@ const Column = (props) => {
                                                       }}
                                                   >
                                                       <div className={c.liflex}>
-                                                          <div className={c.liType}>
-                                                              <svg
-                                                                  className={c.iconSvg}
-                                                                  viewBox="0 0 24 24"
-                                                              >
-                                                                  <path
-                                                                      fill="currentColor"
-                                                                      d="M2,10.96C1.5,10.68 1.35,10.07 1.63,9.59L3.13,7C3.24,6.8 3.41,6.66 3.6,6.58L11.43,2.18C11.59,2.06 11.79,2 12,2C12.21,2 12.41,2.06 12.57,2.18L20.47,6.62C20.66,6.72 20.82,6.88 20.91,7.08L22.36,9.6C22.64,10.08 22.47,10.69 22,10.96L21,11.54V16.5C21,16.88 20.79,17.21 20.47,17.38L12.57,21.82C12.41,21.94 12.21,22 12,22C11.79,22 11.59,21.94 11.43,21.82L3.53,17.38C3.21,17.21 3,16.88 3,16.5V10.96C2.7,11.13 2.32,11.14 2,10.96M12,4.15V4.15L12,10.85V10.85L17.96,7.5L12,4.15M5,15.91L11,19.29V12.58L5,9.21V15.91M19,15.91V12.69L14,15.59C13.67,15.77 13.3,15.76 13,15.6V19.29L19,15.91M13.85,13.36L20.13,9.73L19.55,8.72L13.27,12.35L13.85,13.36Z"
-                                                                  />
-                                                              </svg>
+                                                          <div
+                                                              className={clsx(c.liType, {
+                                                                  [c.liTypeDeprecated]:
+                                                                      isDeprecated,
+                                                                  [c.deprecatedColor]:
+                                                                      isDeprecated && !isActive,
+                                                              })}
+                                                          >
+                                                              {isDeprecated ? (
+                                                                  <FolderOffIcon size="small" />
+                                                              ) : (
+                                                                  <svg
+                                                                      className={c.iconSvg}
+                                                                      viewBox="0 0 24 24"
+                                                                  >
+                                                                      <path
+                                                                          fill="currentColor"
+                                                                          d="M2,10.96C1.5,10.68 1.35,10.07 1.63,9.59L3.13,7C3.24,6.8 3.41,6.66 3.6,6.58L11.43,2.18C11.59,2.06 11.79,2 12,2C12.21,2 12.41,2.06 12.57,2.18L20.47,6.62C20.66,6.72 20.82,6.88 20.91,7.08L22.36,9.6C22.64,10.08 22.47,10.69 22,10.96L21,11.54V16.5C21,16.88 20.79,17.21 20.47,17.38L12.57,21.82C12.41,21.94 12.21,22 12,22C11.79,22 11.59,21.94 11.43,21.82L3.53,17.38C3.21,17.21 3,16.88 3,16.5V10.96C2.7,11.13 2.32,11.14 2,10.96M12,4.15V4.15L12,10.85V10.85L17.96,7.5L12,4.15M5,15.91L11,19.29V12.58L5,9.21V15.91M19,15.91V12.69L14,15.59C13.67,15.77 13.3,15.76 13,15.6V19.29L19,15.91M13.85,13.36L20.13,9.73L19.55,8.72L13.27,12.35L13.85,13.36Z"
+                                                                      />
+                                                                  </svg>
+                                                              )}
                                                           </div>
                                                           <div
                                                               className={clsx(c.liName, {
                                                                   [c.liNameMobile]: isMobile,
+                                                                  [c.deprecatedColor]:
+                                                                      isDeprecated && !isActive,
                                                               })}
                                                               title={result.key}
                                                           >
@@ -1197,6 +1235,11 @@ const Column = (props) => {
                                       const s = r._source || {}
                                       const result = s.archive || {}
                                       const pds4_label = s.pds4_label || {}
+                                      const isDeprecated = (result.uri || result.name || '')
+                                          .toLowerCase()
+                                          .includes('deprecated')
+                                      const isActive =
+                                          params.active && params.active.key === result.name
 
                                       // Exit if not match filter
                                       if (
@@ -1212,10 +1255,7 @@ const Column = (props) => {
                                               key={idx}
                                               ref={idx === 0 ? firstItemRef : null}
                                               className={clsx(c.listItem, c.listItemLessPadding, {
-                                                  [c.listItemActive]:
-                                                      params.active &&
-                                                      params.active.key === result.name,
-
+                                                  [c.listItemActive]: isActive,
                                                   [c.listItemMobile]: isMobile,
                                               })}
                                               onClick={() => {
@@ -1230,7 +1270,13 @@ const Column = (props) => {
                                                   )
                                               }}
                                           >
-                                              <div className={c.liType}>
+                                              <div
+                                                  className={clsx(c.liType, {
+                                                      [c.liTypeDeprecated]: isDeprecated,
+                                                      [c.deprecatedColor]:
+                                                          isDeprecated && !isActive,
+                                                  })}
+                                              >
                                                   {getIn(r._source, ES_PATHS.archive.fs_type) ===
                                                   'file' ? (
                                                       <>
@@ -1242,6 +1288,8 @@ const Column = (props) => {
                                                               <InsertDriveFileOutlinedIcon size="small" />
                                                           )}{' '}
                                                       </>
+                                                  ) : isDeprecated ? (
+                                                      <FolderOffIcon size="small" />
                                                   ) : (
                                                       <FolderIcon size="small" />
                                                   )}
@@ -1250,6 +1298,8 @@ const Column = (props) => {
                                                   <div
                                                       className={clsx(c.liName, {
                                                           [c.liNameMobile]: isMobile,
+                                                          [c.deprecatedColor]:
+                                                              isDeprecated && !isActive,
                                                       })}
                                                       title={result.name}
                                                   >
@@ -1302,7 +1352,8 @@ const Column = (props) => {
                                                                           )
                                                                       }
                                                                   }}
-                                                                  size="large">
+                                                                  size="large"
+                                                              >
                                                                   <GetAppIcon size="small" />
                                                               </IconButton>
                                                           </Tooltip>
@@ -1354,14 +1405,15 @@ const Column = (props) => {
                                                                       )
                                                                   )
                                                               }}
-                                                              size="large">
+                                                              size="large"
+                                                          >
                                                               <AddShoppingCartIcon size="small" />
                                                           </IconButton>
                                                       </Tooltip>
                                                   </div>
                                               </div>
                                           </li>
-                                      );
+                                      )
                                   })}
                         </ul>
                     ) : null}
@@ -1379,7 +1431,7 @@ const Column = (props) => {
                 </div>
             </div>
         </div>
-    );
+    )
 }
 
 let slideTimeout


### PR DESCRIPTION
Closes #209

_With Claude_

<img width="1115" height="331" alt="Screenshot 2026-02-24 174348" src="https://github.com/user-attachments/assets/c90e241b-4608-4264-afa0-88f03282ffea" />


# Support for Filtering Deprecated Folders (#209)
## Overview
Implements filtering for deprecated folders/bundles in Archive-Explorer and       Search pages. Deprecated items are identified by having "deprecated" in their `bundle_id` or `volume_id` URI paths and are now hidden by default to help users focus on current, active data.

  ## Changes

  ### Archive-Explorer
  - **Toggle Control**: Added a three-dot menu (⋮) in bundle/volume column headers 
  with a "Show Deprecated" checkbox
  - **Default Behavior**: Deprecated items are hidden by default
  - **Visual Indicators**: When shown, deprecated items display with:
    - 🗂️❌ `FolderOffIcon` (folder with slash) instead of regular folder/bundle    
  icon
    - Brown/sienna color (#834325) for both icon and text
    - Color reverts to default when item is selected (maintains readability)       

  ### Search Page
  - **Always Filtered**: Deprecated products are automatically excluded from all   
  search results (no toggle needed)
  - Users searching for data will only see current, active products

  ### Technical Implementation

  #### Redux State Management
  **Files**: `actions.js`, `reducers.js`, `initial.js`
  - Added `showDeprecated` boolean state (default: `false`)
  - Created `SET_SHOW_DEPRECATED` action and `setShowDeprecated()` action creator  
  - Added corresponding reducer function

  #### Elasticsearch Query Filtering
  **File**: `src/core/redux/actions/actions.js`

  **Archive-Explorer** (`queryFilexColumn()` ~line 1820):
  ```javascript
  // Filter out deprecated items at ES query level
  const showDeprecated = state.getIn(['showDeprecated'], false)
  if (column.type === 'volume' && !showDeprecated) {
      query.bool.must_not = query.bool.must_not || []
      query.bool.must_not.push({
          wildcard: {
              [ES_PATHS.archive.volume_id.join('.')]: '*deprecated*',
          },
      })
      query.bool.must_not.push({
          wildcard: {
              [ES_PATHS.archive.bundle_id.join('.')]: '*deprecated*',
          },
      })
  }
```
  Search Page (search() ~line 715):
```javascript
  // Always filter out deprecated products in search
  query.bool = query.bool || {}
  query.bool.must_not = query.bool.must_not || []
  query.bool.must_not.push({
      wildcard: {
          'gather.pds_archive.bundle_id': '*deprecated*',
      },
  })
  query.bool.must_not.push({
      wildcard: {
          'gather.pds_archive.volume_id': '*deprecated*',
      },
  })
```
### UI Components

  File: src/pages/FileExplorer/Columns/Columns.js
  - Added FolderOffIcon import for deprecated visual indicator
  - Added DEPRECATED_COLOR constant (#834325)
  - Created CSS classes: liTypeDeprecated, deprecatedColor
  - Added three-dot menu button (MenuButton) with "Show Deprecated" toggle
  - Implemented conditional styling for deprecated items in both volume and        
  directory lists
  - Fixed contrast issues: deprecated color only applies when item is NOT selected 

### Design Decisions

  1. Filtering Level: Server-side (Elasticsearch) for efficiency and reduced data  
  transfer
  2. Default Behavior: Hidden by default in both Archive-Explorer and Search       
  3. Toggle Scope: Global Redux state persists across column navigation
  4. Detection Method: Wildcard match on fields containing "deprecated"
  5. No Toggle for Search: Intentional - search users want current data only       
  6. Performance: ES-level filtering more efficient than client-side filtering     

 ## Testing

 ### Manual Testing Checklist

  - Archive-Explorer: Verify three-dot menu appears before search icon in
  bundle/volume columns
  - Archive-Explorer: Verify "Show Deprecated" checkbox is unchecked by default    
  - Archive-Explorer: Verify no deprecated items appear by default
  - Archive-Explorer: Toggle "Show Deprecated" on and verify deprecated items      
  appear with brown color and special icon
  - Archive-Explorer: Toggle off and verify deprecated items disappear
  - Archive-Explorer: Select a deprecated item and verify text is readable (not    
  brown on blue)
  - Search: Perform various searches and verify no deprecated products appear in   
  results
  - Search: Inspect ES query in Network tab to verify must_not clauses are present 
  - State persistence: Toggle on, navigate through columns, verify state persists  

  ### Edge Cases

  - Missions with no deprecated folders
  - Missions with only deprecated folders
  - Mixed PDS3/PDS4 data
  - Case variations in "deprecated" keyword

##  Visual Changes

 ### Deprecated Items Display:
  - Icon: FolderOffIcon (folder with diagonal slash)
  - Color: Brown/sienna (#834325)
  - Applies to: Both icon and text
  - Selection: Color reverts to default for readability

 ### UI Layout:
  [Bundle/Volume Title]          [⋮ Menu] [🔍 Search]

 ## Performance Impact

  Minimal - filtering occurs at Elasticsearch query level before results are       
  returned, reducing data transfer and client-side processing.