### PR TITLE
Cancel in-flight thumbnail requests and add Record page loading spinner

### DIFF
--- a/src/components/OpenSeadragonViewer/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer/OpenSeadragonViewer.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import OpenSeadragon from 'openseadragon'
 import 'svg-overlay'
 import PropTypes from 'prop-types'
@@ -184,6 +184,9 @@ const OpenSeadragonViewer = ({ image, settings, features, onLayers }) => {
     const [imageLoading, setImageLoading] = useState(true)
     const [svgOverlay, setSvgOverlay] = useState(null)
 
+    const openHandlerRef = useRef(null)
+    const openFailedHandlerRef = useRef(null)
+
     const c = useStyles()
 
     settings = settings || {}
@@ -228,18 +231,26 @@ const OpenSeadragonViewer = ({ image, settings, features, onLayers }) => {
         if (image && image.src && viewer) {
             setOpenFailed(false)
             setImageLoading(true)
-            viewer.removeHandler('open')
-            viewer.removeHandler('open-failed')
-            viewer.addHandler('open', function (e) {
+            if (openHandlerRef.current) {
+                viewer.removeHandler('open', openHandlerRef.current)
+            }
+            if (openFailedHandlerRef.current) {
+                viewer.removeHandler('open-failed', openFailedHandlerRef.current)
+            }
+            const onOpen = function (e) {
                 setImageLoading(false)
                 const so = viewer.svgOverlay()
                 setSvgOverlay(so)
                 drawFeatures(so, features)
-            })
-            viewer.addHandler('open-failed', function () {
+            }
+            const onOpenFailed = function () {
                 setImageLoading(false)
                 setOpenFailed(true)
-            })
+            }
+            openHandlerRef.current = onOpen
+            openFailedHandlerRef.current = onOpenFailed
+            viewer.addHandler('open', onOpen)
+            viewer.addHandler('open-failed', onOpenFailed)
             viewer.open({
                 type: 'image',
                 url: image.src,

--- a/src/components/OpenSeadragonViewer/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer/OpenSeadragonViewer.js
@@ -7,6 +7,7 @@ import clsx from 'clsx'
 
 import { makeStyles } from '@mui/styles'
 
+import CircularProgress from '@mui/material/CircularProgress'
 import IconButton from '@mui/material/IconButton'
 import AddIcon from '@mui/icons-material/Add'
 import RemoveIcon from '@mui/icons-material/Remove'
@@ -75,6 +76,45 @@ const useStyles = makeStyles((theme) => ({
     joiner: {
         borderBottom: '1px solid rgba(0,0,0,0.17)',
     },
+    loadingWrapper: {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        pointerEvents: 'none',
+        opacity: 1,
+        transition: 'opacity 0.4s ease-out',
+    },
+    loadingHidden: {
+        opacity: 0,
+    },
+    loadingPaper: {
+        'background': theme.palette.accent.main,
+        'pointerEvents': 'none',
+        '& > div': {
+            padding: `${theme.spacing(4)} ${theme.spacing(6)}`,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+        },
+    },
+    loadingProgress: {
+        'marginBottom': theme.spacing(1.5),
+        '& .MuiCircularProgress-colorPrimary': {
+            color: theme.palette.text.secondary,
+        },
+    },
+    loadingText: {
+        color: theme.palette.text.secondary,
+        fontSize: '14px',
+        fontWeight: 'bold',
+        letterSpacing: '1px',
+        textAlign: 'center',
+    },
     openFailedWrapper: {
         opacity: 0,
         transition: `0.2s ease-in opacity`,
@@ -141,6 +181,7 @@ const useStyles = makeStyles((theme) => ({
 const OpenSeadragonViewer = ({ image, settings, features, onLayers }) => {
     const [viewer, setViewer] = useState(null)
     const [openFailed, setOpenFailed] = useState(false)
+    const [imageLoading, setImageLoading] = useState(true)
     const [svgOverlay, setSvgOverlay] = useState(null)
 
     const c = useStyles()
@@ -186,11 +227,18 @@ const OpenSeadragonViewer = ({ image, settings, features, onLayers }) => {
     useEffect(() => {
         if (image && image.src && viewer) {
             setOpenFailed(false)
+            setImageLoading(true)
             viewer.removeHandler('open')
+            viewer.removeHandler('open-failed')
             viewer.addHandler('open', function (e) {
+                setImageLoading(false)
                 const so = viewer.svgOverlay()
                 setSvgOverlay(so)
                 drawFeatures(so, features)
+            })
+            viewer.addHandler('open-failed', function () {
+                setImageLoading(false)
+                setOpenFailed(true)
             })
             viewer.open({
                 type: 'image',
@@ -216,12 +264,7 @@ const OpenSeadragonViewer = ({ image, settings, features, onLayers }) => {
                 }
             })
         }
-        // Set open failed event
-        if (viewer) {
-            viewer.addHandler('open-failed', () => {
-                setOpenFailed(true)
-            })
-        }
+        // open-failed is handled in the image loading useEffect above
     }, [viewer])
 
     return (
@@ -295,6 +338,16 @@ const OpenSeadragonViewer = ({ image, settings, features, onLayers }) => {
                         <RemoveIcon fontSize="inherit" />
                     </IconButton>
                 </div>
+            </div>
+            <div className={clsx(c.loadingWrapper, { [c.loadingHidden]: !imageLoading || openFailed })}>
+                <Paper className={c.loadingPaper} elevation={2}>
+                    <div>
+                        <div className={c.loadingProgress}>
+                            <CircularProgress size={36} />
+                        </div>
+                        <div className={c.loadingText}>LOADING</div>
+                    </div>
+                </Paper>
             </div>
             <div className={clsx(c.openFailedWrapper, { [c.openFailedShown]: openFailed })}>
                 <div className={clsx(c.status, { [c.statusHidden]: !openFailed })}>

--- a/src/components/OpenSeadragonViewer/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer/OpenSeadragonViewer.js
@@ -98,12 +98,12 @@ const useStyles = makeStyles((theme) => ({
         '& > div': {
             padding: `${theme.spacing(4)} ${theme.spacing(6)}`,
             display: 'flex',
-            flexDirection: 'column',
             alignItems: 'center',
         },
     },
     loadingProgress: {
-        'marginBottom': theme.spacing(1.5),
+        'marginTop': '1px',
+        'marginRight': theme.spacing(2),
         '& .MuiCircularProgress-colorPrimary': {
             color: theme.palette.text.secondary,
         },
@@ -280,7 +280,8 @@ const OpenSeadragonViewer = ({ image, settings, features, onLayers }) => {
                         onClick={() => {
                             viewer.viewport.setRotation(0)
                         }}
-                        size="large">
+                        size="large"
+                    >
                         <HomeIcon fontSize="inherit" />
                     </IconButton>
                     <IconButton
@@ -288,7 +289,8 @@ const OpenSeadragonViewer = ({ image, settings, features, onLayers }) => {
                         className={clsx(c.button, c.gap)}
                         title="Fullscreen"
                         aria-label="image view fullscreen"
-                        size="large">
+                        size="large"
+                    >
                         <FullscreenIcon fontSize="inherit" />
                     </IconButton>
                     <IconButton
@@ -296,7 +298,8 @@ const OpenSeadragonViewer = ({ image, settings, features, onLayers }) => {
                         className={clsx(c.button, c.joiner)}
                         title="Rotate Counter-Clockwise"
                         aria-label="image view rotate counter clockwise"
-                        size="large">
+                        size="large"
+                    >
                         <RotateLeftIcon fontSize="inherit" />
                     </IconButton>
                     <IconButton
@@ -304,7 +307,8 @@ const OpenSeadragonViewer = ({ image, settings, features, onLayers }) => {
                         className={c.button}
                         title="Rotate Clockwise"
                         aria-label="image view rotate clockwise"
-                        size="large">
+                        size="large"
+                    >
                         <RotateRightIcon fontSize="inherit" />
                     </IconButton>
                 </div>
@@ -315,7 +319,8 @@ const OpenSeadragonViewer = ({ image, settings, features, onLayers }) => {
                             title="Layers"
                             aria-label="image view layers"
                             onClick={onLayers}
-                            size="large">
+                            size="large"
+                        >
                             <LayersIcon fontSize="inherit" />
                         </IconButton>
                     ) : null}
@@ -326,7 +331,8 @@ const OpenSeadragonViewer = ({ image, settings, features, onLayers }) => {
                         className={clsx(c.button, c.joiner)}
                         title="Zoom In"
                         aria-label="image view zoom in"
-                        size="large">
+                        size="large"
+                    >
                         <AddIcon fontSize="inherit" />
                     </IconButton>
                     <IconButton
@@ -334,16 +340,21 @@ const OpenSeadragonViewer = ({ image, settings, features, onLayers }) => {
                         className={c.button}
                         title="Zoom Out"
                         aria-label="image view zoom out"
-                        size="large">
+                        size="large"
+                    >
                         <RemoveIcon fontSize="inherit" />
                     </IconButton>
                 </div>
             </div>
-            <div className={clsx(c.loadingWrapper, { [c.loadingHidden]: !imageLoading || openFailed })}>
+            <div
+                className={clsx(c.loadingWrapper, {
+                    [c.loadingHidden]: !imageLoading || openFailed,
+                })}
+            >
                 <Paper className={c.loadingPaper} elevation={2}>
                     <div>
                         <div className={c.loadingProgress}>
-                            <CircularProgress size={36} />
+                            <CircularProgress size={20} />
                         </div>
                         <div className={c.loadingText}>LOADING</div>
                     </div>
@@ -368,7 +379,7 @@ const OpenSeadragonViewer = ({ image, settings, features, onLayers }) => {
                 </div>
             </div>
         </div>
-    );
+    )
 }
 
 function drawFeatures(overlay, features) {

--- a/src/pages/Search/Panels/ResultsPanel/subcomponents/GridView/GridView.js
+++ b/src/pages/Search/Panels/ResultsPanel/subcomponents/GridView/GridView.js
@@ -190,6 +190,15 @@ const GridView = (props) => {
         align: 'top',
     })
 
+    // On unmount, cancel in-flight thumbnail image requests to free up
+    // browser HTTP connection slots for the next page
+    useEffect(() => {
+        return () => {
+            const imgs = document.querySelectorAll('.ResultsPanelImage')
+            imgs.forEach((img) => { img.src = '' })
+        }
+    }, [])
+
     // On mount, if the user is coming from another view and has scroll to
     // some position in it, scroll to that same item
     useEffect(() => {

--- a/src/pages/Search/Panels/ResultsPanel/subcomponents/GridView/GridView.js
+++ b/src/pages/Search/Panels/ResultsPanel/subcomponents/GridView/GridView.js
@@ -194,7 +194,7 @@ const GridView = (props) => {
     // browser HTTP connection slots for the next page
     useEffect(() => {
         return () => {
-            const imgs = document.querySelectorAll('.ResultsPanelImage')
+            const imgs = document.querySelectorAll('.GridViewImage')
             imgs.forEach((img) => { img.src = '' })
         }
     }, [])
@@ -324,7 +324,7 @@ const GridCard = ({ index, data, width }) => {
             }}
         >
             <Image
-                className={`${c.gridItemImage} ResultsPanelImage`}
+                className={`${c.gridItemImage} GridViewImage`}
                 wrapperStyle={{
                     height: '100%',
                     paddingTop: 'unset',

--- a/src/pages/Search/Panels/ResultsPanel/subcomponents/GridView/GridView.js
+++ b/src/pages/Search/Panels/ResultsPanel/subcomponents/GridView/GridView.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useLayoutEffect, useRef } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 import {
@@ -192,7 +192,7 @@ const GridView = (props) => {
 
     // On unmount, cancel in-flight thumbnail image requests to free up
     // browser HTTP connection slots for the next page
-    useEffect(() => {
+    useLayoutEffect(() => {
         return () => {
             const imgs = document.querySelectorAll('.GridViewImage')
             imgs.forEach((img) => { img.src = '' })

--- a/src/pages/Search/Panels/ResultsPanel/subcomponents/GridView/GridView.js
+++ b/src/pages/Search/Panels/ResultsPanel/subcomponents/GridView/GridView.js
@@ -324,7 +324,7 @@ const GridCard = ({ index, data, width }) => {
             }}
         >
             <Image
-                className={`${c.gridItemImage} GridViewImage`}
+                className={`${c.gridItemImage} ResultsPanelImage GridViewImage`}
                 wrapperStyle={{
                     height: '100%',
                     paddingTop: 'unset',

--- a/src/pages/Search/Panels/ResultsPanel/subcomponents/ListView/ListView.js
+++ b/src/pages/Search/Panels/ResultsPanel/subcomponents/ListView/ListView.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useLayoutEffect } from 'react'
 import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 import {
@@ -220,7 +220,7 @@ const ListView = (props) => {
 
     // On unmount, cancel in-flight thumbnail image requests to free up
     // browser HTTP connection slots for the next page
-    useEffect(() => {
+    useLayoutEffect(() => {
         return () => {
             const imgs = document.querySelectorAll('.ListViewImage')
             imgs.forEach((img) => { img.src = '' })

--- a/src/pages/Search/Panels/ResultsPanel/subcomponents/ListView/ListView.js
+++ b/src/pages/Search/Panels/ResultsPanel/subcomponents/ListView/ListView.js
@@ -343,7 +343,7 @@ const ListCard = ({ index, data, width }) => {
         >
             <div className={c.listItemLeft}>
                 <Image
-                    className={`${c.listItemImage} ListViewImage`}
+                    className={`${c.listItemImage} ResultsPanelImage ListViewImage`}
                     wrapperStyle={{
                         height: '100%',
                         paddingTop: 'unset',

--- a/src/pages/Search/Panels/ResultsPanel/subcomponents/ListView/ListView.js
+++ b/src/pages/Search/Panels/ResultsPanel/subcomponents/ListView/ListView.js
@@ -222,7 +222,7 @@ const ListView = (props) => {
     // browser HTTP connection slots for the next page
     useEffect(() => {
         return () => {
-            const imgs = document.querySelectorAll('.listItemImage img')
+            const imgs = document.querySelectorAll('.ResultsPanelImage')
             imgs.forEach((img) => { img.src = '' })
         }
     }, [])
@@ -343,7 +343,7 @@ const ListCard = ({ index, data, width }) => {
         >
             <div className={c.listItemLeft}>
                 <Image
-                    className={c.listItemImage}
+                    className={`${c.listItemImage} ResultsPanelImage`}
                     wrapperStyle={{
                         height: '100%',
                         paddingTop: 'unset',

--- a/src/pages/Search/Panels/ResultsPanel/subcomponents/ListView/ListView.js
+++ b/src/pages/Search/Panels/ResultsPanel/subcomponents/ListView/ListView.js
@@ -222,7 +222,7 @@ const ListView = (props) => {
     // browser HTTP connection slots for the next page
     useEffect(() => {
         return () => {
-            const imgs = document.querySelectorAll('.ResultsPanelImage')
+            const imgs = document.querySelectorAll('.ListViewImage')
             imgs.forEach((img) => { img.src = '' })
         }
     }, [])
@@ -343,7 +343,7 @@ const ListCard = ({ index, data, width }) => {
         >
             <div className={c.listItemLeft}>
                 <Image
-                    className={`${c.listItemImage} ResultsPanelImage`}
+                    className={`${c.listItemImage} ListViewImage`}
                     wrapperStyle={{
                         height: '100%',
                         paddingTop: 'unset',

--- a/src/pages/Search/Panels/ResultsPanel/subcomponents/ListView/ListView.js
+++ b/src/pages/Search/Panels/ResultsPanel/subcomponents/ListView/ListView.js
@@ -218,6 +218,15 @@ const ListView = (props) => {
         align: 'top',
     })
 
+    // On unmount, cancel in-flight thumbnail image requests to free up
+    // browser HTTP connection slots for the next page
+    useEffect(() => {
+        return () => {
+            const imgs = document.querySelectorAll('.listItemImage img')
+            imgs.forEach((img) => { img.src = '' })
+        }
+    }, [])
+
     // On mount, if the user is coming from another view and has scroll to
     // some position in it, scroll to that same item
     useEffect(() => {

--- a/src/pages/Search/Panels/ResultsPanel/subcomponents/TableView/TableView.js
+++ b/src/pages/Search/Panels/ResultsPanel/subcomponents/TableView/TableView.js
@@ -267,6 +267,15 @@ const TableView = (props) => {
 
     const [columnWidths, setColumnWidths] = useState([32, 32, 520].concat(Array(497).fill(200)))
 
+    // On unmount, cancel in-flight thumbnail image requests to free up
+    // browser HTTP connection slots for the next page
+    useEffect(() => {
+        return () => {
+            const imgs = document.querySelectorAll('.hoverImage')
+            imgs.forEach((img) => { img.src = '' })
+        }
+    }, [])
+
     const headerRef = React.useRef(null)
     const tableContainerRef = React.useRef(null)
 

--- a/src/pages/Search/Panels/ResultsPanel/subcomponents/TableView/TableView.js
+++ b/src/pages/Search/Panels/ResultsPanel/subcomponents/TableView/TableView.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 import {
@@ -269,7 +269,7 @@ const TableView = (props) => {
 
     // On unmount, cancel in-flight thumbnail image requests to free up
     // browser HTTP connection slots for the next page
-    useEffect(() => {
+    useLayoutEffect(() => {
         return () => {
             const imgs = document.querySelectorAll('.hoverImage')
             imgs.forEach((img) => { img.src = '' })


### PR DESCRIPTION
_With Devin_

https://github.com/JPL-Devin/atlas/pull/2

## 🗒️ Summary

This PR addresses two related issues with Record page image loading:

### 1. Cancel in-flight thumbnail requests on search view unmount

When navigating from the Search page to the Record page, in-flight thumbnail HTTP requests from search results continue to occupy the browser's connection pool, delaying the Record page's OpenSeadragonViewer image load. This PR adds `useLayoutEffect` cleanup hooks to the three search result view components (`GridView`, `ListView`, `TableView`) that clear thumbnail `img.src` on unmount, aborting pending requests and freeing connection slots.

**Changes per file:**
- **GridView.js** — adds unmount cleanup querying `.GridViewImage`; adds new `GridViewImage` static class alongside existing `ResultsPanelImage`
- **ListView.js** — adds unmount cleanup querying `.ListViewImage`; adds both `ResultsPanelImage` (previously missing — only had JSS-generated `c.listItemImage`) and `ListViewImage` static classes to the `<Image>` element
- **TableView.js** — adds unmount cleanup querying `.hoverImage` (existing static class via `clsx`)

Each view uses a **view-specific** class name for its cleanup selector (`GridViewImage`, `ListViewImage`, `hoverImage`) to avoid cross-view interference when switching between Grid ↔ List views. The original `ResultsPanelImage` class is preserved on both GridView and ListView images so that `Heading.js`'s `rotate90()` function (which queries `getElementsByClassName('ResultsPanelImage')`) continues to work.

#### Why `useLayoutEffect` instead of `useEffect`

In React 18, `useEffect` cleanup (passive effects) runs **after** DOM mutations — by the time it fires, React has already removed the component's DOM subtree via `removeChild`, so `querySelectorAll` returns an empty NodeList and the cleanup is a no-op. `useLayoutEffect` cleanup runs **synchronously during** `commitDeletionEffects`, **before** the DOM node is removed, so the query finds all img elements as intended.

### 2. Add loading spinner to OpenSeadragonViewer

Adds a themed loading spinner to the `OpenSeadragonViewer` component that displays while an image is loading. This benefits both the **Overview** and **ML Classification** views on the Record page.

**Changes in OpenSeadragonViewer.js:**
- Adds `imageLoading` state (defaults to `true`)
- Sets `imageLoading = true` when `viewer.open()` is called, `false` on the `open` event
- Consolidates the `open-failed` handler into the image loading `useEffect` (previously it was a separate handler in the `[viewer]` effect)
- Uses `useRef` to store handler function references (`openHandlerRef`, `openFailedHandlerRef`) so that `viewer.removeHandler()` can properly remove previous handlers before re-registering — OpenSeadragon's `removeHandler` requires the exact handler reference as the second argument
- Renders a centered `CircularProgress` spinner with "LOADING" text inside an accent-colored `Paper` overlay
- Spinner fades out (0.4s opacity transition) when the image loads or fails

**Styling** is themed to match the existing loading indicators:
- **Search page** (`ResultsStatus.js`) — uses the same `CircularProgress` component with `theme.palette.accent.main` background and `theme.palette.text.secondary` color
- **ThreeViewer** model loading — uses the same accent `Paper`, bold uppercase text with `letterSpacing: '1px'`

