### PR TITLE
Set the ESLint option emitError to false in our webpack configuration…

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -518,6 +518,7 @@ module.exports = function (webpackEnv) {
                         extensions: ["js", "mjs", "jsx", "ts", "tsx"],
                         eslintPath: require.resolve("eslint"),
                         cache: true,
+                        emitError: false,
                         failOnError: isEnvProduction,
                         failOnWarning: false,
                     });


### PR DESCRIPTION
… so that when the application runs in dev mode, we can interact with the application. This was a quick fix as the ESLint Overlay in dev mode wasn't visible in the browser either.

<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary

This PR introduced a change to our ESLint set up in webpack's configuration. We've added the `emitError` option and set it to `false` so that when the application is run in dev mode, we can interact with it in the browser. Without this setting, the dev cannot interact with the application because ESLint adds an overlay that sits above the application. THe overlay isn't visible which may be a separate issue. So for now we chose not to emitErrors during dev builds and will rely on the stand along lint command or build:lint command to check for linting errors.

## ⚙️ Test Data and/or Report
One of the following should be included here:
* Reference to regression test included in code (preferred wherever reasonable)
* Attach test data here + outputs of tests

Tested locally by verifying that the application can be interacted with when the setting was set to false and not interacted with when the setting was set to true, which was the default.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Resolves #275 

