### PR TITLE
Fix bundle deeplink column index after instrument filter removal

### DIFF
--- a/src/core/redux/actions/actions.js
+++ b/src/core/redux/actions/actions.js
@@ -1662,7 +1662,7 @@ export const updateFilexColumn = (columnId, options, stopPropagate, forcePropaga
                                       },
                                   }
                                 : null
-                        if (nextVolActive) dispatch(updateFilexColumn(2, nextVolActive))
+                        if (nextVolActive) dispatch(updateFilexColumn(1, nextVolActive))
 
                         let rawPath = url.query.uri || ''
                         const splittedUri = splitUri(rawPath)

--- a/src/core/redux/actions/actions.js
+++ b/src/core/redux/actions/actions.js
@@ -1692,7 +1692,7 @@ export const updateFilexColumn = (columnId, options, stopPropagate, forcePropaga
                                     uriPrefix +
                                     rawPath.substring(
                                         0,
-                                        lastMatch + key.length + (isFinalFile ? 0 : 1)
+                                        lastMatch + key.length + 1
                                     )
                                 // || rawPathFinal === key
 
@@ -1703,6 +1703,7 @@ export const updateFilexColumn = (columnId, options, stopPropagate, forcePropaga
                                             active: {
                                                 key: isFinalFile ? key.slice(0, -1) : key,
                                                 uri: isFinalFile ? uri.slice(0, -1) : uri,
+                                                fs_type: isFinalFile ? 'file' : null,
                                                 _needsData: isFinalFile,
                                             },
                                         },

--- a/src/core/redux/actions/actions.js
+++ b/src/core/redux/actions/actions.js
@@ -1698,7 +1698,7 @@ export const updateFilexColumn = (columnId, options, stopPropagate, forcePropaga
 
                                 dispatch(
                                     updateFilexColumn(
-                                        pathId + 3,
+                                        pathId + 2,
                                         {
                                             active: {
                                                 key: isFinalFile ? key.slice(0, -1) : key,
@@ -2095,7 +2095,7 @@ export const goToFilexURI = (uri) => {
 
             dispatch(
                 updateFilexColumn(
-                    pathId + 3,
+                    pathId + 2,
                     {
                         active: {
                             key: isFinalFile ? key.slice(0, -1) : key,


### PR DESCRIPTION
_With Devin_: https://github.com/JPL-Devin/atlas/pull/9

## 🗒️ Summary

The instrument filter column (index 1) was disabled/commented out as part of TS-194 (lines 1624–1646 in `actions.js`), but several hardcoded column indices were not updated to reflect the shifted layout. Additionally, the deeplink path restoration `add()` function had two bugs preventing final file selection.

### Column index fixes (TS-194 offset):
1. **Line 1665:** `updateFilexColumn(2, nextVolActive)` → `updateFilexColumn(1, nextVolActive)` — fixes the `bundle` URL parameter targeting a non-existent column.
2. **Line 1701:** `updateFilexColumn(pathId + 3, ...)` → `updateFilexColumn(pathId + 2, ...)` — fixes deeplink path segment restoration.
3. **Line 2098:** `updateFilexColumn(pathId + 3, ...)` → `updateFilexColumn(pathId + 2, ...)` — fixes `goToFilexURI` path navigation.

### Deeplink file selection fixes:
4. **Line 1695:** URI substring used `(isFinalFile ? 0 : 1)` which already excluded the trailing `-` marker, but then `uri.slice(0, -1)` on line 1705 stripped one MORE real character, corrupting the URI. Changed to always use `+ 1` so the `-` is included in the substring and properly stripped by the existing `slice(0, -1)`. This aligns with the `goToFilexURI` URI calculation.
5. **Line 1706:** Added missing `fs_type: isFinalFile ? 'file' : null` to match `goToFilexURI`. Without this, `setFilexPreview` was never called for deeplinked files since `options.active.fs_type === 'file'` was always false.

## ⚙️ Test Data and/or Report

Verify that:
1. `/archive-explorer?mission=mars_2020&bundle=mars2020_mastcamz_sci_calibrated` correctly selects the bundle in the volume column.
2. `/archive-explorer?mission=mars_2020&bundle=mars2020_mastcamz_ops_calibrated&pds=4&uri=atlas:pds4:mars_2020:perseverance:/mars2020_mastcamz_ops_calibrated/bundle.xml-` selects the mission, bundle, AND final file.
3. The `pds` query param (for PDS standard) is correctly applied when present.
4. Basic archive-explorer navigation (clicking mission → bundle → directories) still works without the deeplink.
5. Deep path URIs with nested path segments correctly navigate to the target directory/file.

## ♻️ Related Issues

- refs TS-194