### PR TITLE
Fix stuck loading spinner and duplicate search cycles on short result sets

### DIFF
--- a/src/pages/Search/Panels/ResultsPanel/subcomponents/GridView/GridView.js
+++ b/src/pages/Search/Panels/ResultsPanel/subcomponents/GridView/GridView.js
@@ -245,7 +245,7 @@ const GridView = (props) => {
                 const pxFromTop = scrollTop
                 const pxFromBottom = masonryHeight - (scrollTop + height)
 
-                if (pxFromBottom < gridItemHeight * 2) {
+                if (pxFromBottom < gridItemHeight * 2 && results.length < paging.total) {
                     dispatch(search(parseInt(results.length / resultsPerPage)))
                     allowPageCheck = false
                 }

--- a/src/pages/Search/Panels/ResultsPanel/subcomponents/ListView/ListView.js
+++ b/src/pages/Search/Panels/ResultsPanel/subcomponents/ListView/ListView.js
@@ -272,7 +272,7 @@ const ListView = (props) => {
                 const pxFromTop = scrollTop
                 const pxFromBottom = masonryHeight - (scrollTop + height)
 
-                if (pxFromBottom < listItemHeight * 2) {
+                if (pxFromBottom < listItemHeight * 2 && results.length < paging.total) {
                     dispatch(search(parseInt(results.length / resultsPerPage)))
                     allowPageCheck = false
                 }

--- a/src/pages/Search/Panels/ResultsPanel/subcomponents/TableView/TableView.js
+++ b/src/pages/Search/Panels/ResultsPanel/subcomponents/TableView/TableView.js
@@ -284,7 +284,7 @@ const TableView = (props) => {
     }
     // Load More
     const loadData = () => {
-        if (loadedMore) {
+        if (loadedMore && results.length < paging.total) {
             loadedMore = false
             dispatch(search(parseInt(results.length / resultsPerPage)))
         }


### PR DESCRIPTION
_With Devin_: https://github.com/JPL-Devin/atlas/pull/17

## 🗒️ Summary

Submitting a text query that returns fewer results than fill the viewport (e.g. `PCD_0600_0720244851_000FDRTN030000020853606902300LUJ02`, 1 hit) loaded the result in the grid but the spinner kept spinning through extra query cycles before the user could interact.

**Root cause:** the infinite-scroll "load more" in the results views never checked whether more results actually existed. When a short result set left the viewport under-filled, `pxFromBottom < threshold` stayed true, so the effect repeatedly dispatched `search(parseInt(results.length / resultsPerPage))` — which computes page `0` for a 1-result set, re-running the *same* full query. Each of those calls resets `resultsStatus` to `SEARCHING` (`actions.js:354`), so the spinner never cleared (`ResultsStatus` only hides on `SUCCESSFUL`). Empirically a single text submit fired 3 identical `from:0` `_search` POSTs instead of 1.

**Fix:** only trigger load-more when there are more results to fetch, i.e. `results.length < paging.total`. Applied to all three result views:

```diff
- if (pxFromBottom < gridItemHeight * 2) {
+ if (pxFromBottom < gridItemHeight * 2 && results.length < paging.total) {
      dispatch(search(parseInt(results.length / resultsPerPage)))
```

(same guard in `ListView.js`; `TableView.loadData` gains `&& results.length < paging.total`).

Note: the actual reproduced cause was this load-more loop, not the `if (!urlHasQuery)` branch — all extra requests were identical page-0 text queries, with no URL-driven `match_all` request observed.

## ⚙️ Test Data and/or Report

Verified locally against the live search backend:

| Scenario | Before | After |
|---|---|---|
| Text query (1 result) | 3 `_search` POSTs, spinner stuck `SEARCHING` | 1 POST, spinner clears, "1 of 1" shown |
| Empty query (64.4M results) | 1 POST on load | unchanged (1 POST) |
| Scroll to bottom of 100 results | load-more `from:100` | load-more `from:100` (pagination intact) |

Initial-mount search, clear/reset, and filter-driven searches all still behave correctly.
